### PR TITLE
pass in auth

### DIFF
--- a/src/agentor/sdk/client.py
+++ b/src/agentor/sdk/client.py
@@ -10,6 +10,8 @@ class _BaseConnection:
         self.base_url = base_url or self._BASE_URL
         if not api_key:
             raise ValueError("token is required.")
+        self.api_key = api_key
+        self.session = httpx.Client(cookies={"access_token": api_key})
 
 
 class _BaseClient:
@@ -20,14 +22,24 @@ class _BaseClient:
     def base_url(self):
         return self._base_connection.base_url
 
+    @property
+    def api_key(self):
+        return self._base_connection.api_key
+
+    @property
+    def session(self):
+        return self._base_connection.session
+
 
 class ToolHub(_BaseClient):
     def list_tools(self) -> List[dict[str, str]]:
-        return httpx.get(f"{self.base_url}/toolhub/list").json()
+        return self.session.get(f"{self.base_url}/toolhub/list").json()
 
     def run_weather_tool(self, city: str) -> dict:
-        return httpx.get(
-            f"{self.base_url}/toolhub/current-weather", params={"city": city}
+        return self.session.get(
+            f"{self.base_url}/toolhub/current-weather",
+            params={"city": city},
+            cookies={"access_token": f"Bearer {self.api_key}"},
         ).json()
 
 


### PR DESCRIPTION
This pull request improves authentication handling and client session management in the `agentor.sdk.client` module. The main changes ensure that all API requests consistently use a session with the correct authentication token, and simplify access to authentication and session objects throughout the client classes.

**Authentication and session management improvements:**

* The `__init__` method of the base connection now stores the `api_key` and initializes an `httpx.Client` session with the `access_token` cookie, ensuring all requests use the correct authentication.
* The `_BaseClient` class exposes `api_key` and `session` as properties, allowing derived clients to easily access these for making authenticated requests.

**API request updates:**

* The `ToolHub` client now uses the shared session for all requests, replacing direct calls to `httpx.get`. This ensures requests are authenticated and consistent.
* The `run_weather_tool` method explicitly passes the `access_token` as a cookie in the request, further ensuring proper authentication.