### PR TITLE
API key error handling

### DIFF
--- a/examples/weather_agent.py
+++ b/examples/weather_agent.py
@@ -1,5 +1,6 @@
 from agentor import Agentor
 
+# This example uses the get_weather tool from the Celesto AI Tool Hub registry
 agent = Agentor(
     name="Weather Agent",
     model="gpt-5-mini",

--- a/src/agentor/agents.py
+++ b/src/agentor/agents.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import json
 import traceback
@@ -149,6 +150,10 @@ class Agentor(AgentServer):
         self.name = name
         self.instructions = instructions
         self.model = model
+
+        if os.environ.get("OPENAI_API_KEY") is None:
+            raise ValueError("""OPENAI_API_KEY is required to use the Agentor.
+            Please set the OPENAI_API_KEY environment variable.""")
         self.agent: Agent = Agent(
             name=name, instructions=instructions, model=model, tools=tools
         )

--- a/src/agentor/tools/registry.py
+++ b/src/agentor/tools/registry.py
@@ -1,14 +1,3 @@
-"""
-agent = Agentor(
-    name="Agentor",
-    model="gpt-5-mini",
-    tools=["celestoai/get_weather"]
-)
-
-result = agent.run("What is the weather in London?")
-print(result)
-"""
-
 from typing import Callable, List, Union
 from agentor.sdk.client import CelestoSDK
 from agents import FunctionTool, RunContextWrapper, function_tool
@@ -87,6 +76,8 @@ def current_datetime(wrapper: RunContextWrapper[CelestoConfig]) -> str:
 
 
 class ToolRegistry:
+    """Registry for tools."""
+
     @staticmethod
     def get(name: str) -> Union[FunctionTool, Callable]:
         try:


### PR DESCRIPTION
Add environment variable check for OPENAI_API_KEY and update weather agent example

This commit introduces a check for the OPENAI_API_KEY environment variable in the Agentor class to ensure that it is set before proceeding with agent initialization. If the variable is not set, a ValueError is raised with a clear message. Additionally, a comment has been added to the weather agent example to clarify its usage of the get_weather tool from the Celesto AI Tool Hub registry, enhancing the documentation for users.

These changes improve error handling and provide better guidance for utilizing the weather agent effectively.