### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: pytest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CelestoAI/agentor/security/code-scanning/2](https://github.com/CelestoAI/agentor/security/code-scanning/2)

To mitigate the risk associated with excessive GIHTUB_TOKEN permissions, explicitly set the `permissions` block to the least privilege necessary. As the workflow only needs to check out code and upload coverage (which does not require write access), set `permissions: { contents: read }` either at the workflow root (before `jobs:`), to affect all jobs, or within the only job (`pytest`). The best practice is to set it at the root so future jobs inherit the restriction by default. No code outside `.github/workflows/test.yml` needs to change. No additional dependencies or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
