### PR TITLE
Update AgentorBase to support multiple LLM API key environment variables

### DIFF
--- a/src/agentor/agents/core.py
+++ b/src/agentor/agents/core.py
@@ -77,10 +77,12 @@ class AgentorBase:
         self.model = model
 
         if llm_api_key is None:
-            llm_api_key = os.environ.get("OPENAI_API_KEY")
+            llm_api_key = os.environ.get("LLM_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
         if llm_api_key is None:
-            raise ValueError("""OPENAI_API_KEY is required to use the Agentor.
-                Please set the OPENAI_API_KEY environment variable.""")
+            raise ValueError("""An LLM API key is required to use the Agentor.
+                Please set either LLM_API_KEY/OPENAI_API_KEY environment variable or pass it as an argument.""")
         self.llm_api_key = llm_api_key
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,3 +1,4 @@
+import pytest
 from agentor.agents import Agentor
 from agentor.prompts import THINKING_PROMPT, render_prompt
 from unittest.mock import MagicMock, patch
@@ -56,3 +57,13 @@ def test_agentor_create_app():
     assert app.router is not None
     assert app.router.routes is not None
     assert len(app.router.routes) == 8
+
+
+def test_agentor_without_llm_api_key():
+    with pytest.raises(
+        ValueError, match="An LLM API key is required to use the Agentor."
+    ):
+        Agentor(
+            name="Agentor",
+            model="gpt-5-mini",
+        )


### PR DESCRIPTION
- Modified the initialization of llm_api_key to check for LLM_API_KEY first, falling back to OPENAI_API_KEY if not set.
- Updated the error message to clarify the requirement for either LLM_API_KEY or OPENAI_API_KEY.