### PR TITLE
Auto env variable injection from `.env` files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,8 @@ uv run ruff check --fix .
 
 ## Testing
 
+We use PyTest and follow the functional style.
+
 ### Running Tests
 
 Run the full test suite:

--- a/examples/agent-server/client.py
+++ b/examples/agent-server/client.py
@@ -1,9 +1,12 @@
 import os
 import requests
+import dotenv
+
+dotenv.load_dotenv()
 
 # When deployed to Celesto (agentor deploy --folder ./examples/agent-server)
-# URL = "https://api.celesto.ai/v1/deploy/apps/my-agent-name/chat"
-URL = "http://localhost:8000/chat"
+URL = "https://api.celesto.ai/v1/deploy/apps/my-agent/chat"
+# URL = "http://localhost:8000/chat"
 CELESTO_API_KEY = os.environ.get("CELESTO_API_KEY")
 
 headers = {

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from agentor.deployment import _resolve_envs
+
+
+def test_resolve_envs_merges_file_and_cli(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("FIRST=1\nSECOND=two\nEMPTY=\n", encoding="utf-8")
+
+    result = _resolve_envs(
+        folder_path=tmp_path,
+        envs="SECOND=override, CLI_ONLY=foo",
+        ignore_env_file=False,
+    )
+
+    assert result == {"FIRST": "1", "SECOND": "override", "CLI_ONLY": "foo"}
+
+
+def test_resolve_envs_ignores_file_when_flag_set(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("FIRST=1\n", encoding="utf-8")
+
+    result = _resolve_envs(folder_path=tmp_path, envs=None, ignore_env_file=True)
+
+    assert result == {}


### PR DESCRIPTION
`agentor deploy` will automatically inject .env values based on `.env` file. To ignore the .env file, set `--ignore-env-file`