### PR TITLE
Allow chat input with list of dict[role, content]

### DIFF
--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -74,6 +74,11 @@ class APIInputRequest(BaseModel):
     stream: bool = False
 
 
+class AgentInputType(TypedDict):
+    role: Literal["user", "assistant", "system"]
+    content: str
+
+
 class AgentorBase:
     def __init__(
         self,
@@ -312,7 +317,7 @@ class Agentor(AgentorBase):
 
     async def arun(
         self,
-        input: list[str] | str,
+        input: list[str] | str | list[AgentInputType],
         limit_concurrency: int = 10,
         max_turns: int = 10,
     ) -> List[str] | str:
@@ -326,6 +331,9 @@ class Agentor(AgentorBase):
             max_turns: The maximum number of turns to run the agent.
         """
         if isinstance(input, list):
+            if isinstance(input[0], dict):
+                return await Runner.run(self.agent, input, context=CelestoConfig())
+
             futures = []
             if limit_concurrency > 0:
                 semaphore = asyncio.Semaphore(limit_concurrency)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -203,3 +203,22 @@ You are a helpful assistant."""
     agent = Agentor.from_md(md_file, api_key="test-key", model_settings=model_settings)
 
     assert agent.agent.model_settings.temperature == 0.8
+
+
+@pytest.mark.asyncio
+@patch("agentor.core.agent.Runner.run")
+async def test_arun_with_agent_input_type(mock_run):
+    mock_run.return_value = MagicMock(final_output="The weather in London is sunny")
+    agent = Agentor(
+        name="Test agent",
+        api_key="test-key",
+    )
+    result = await agent.arun(
+        [{"role": "user", "content": "What is the weather in London?"}]
+    )
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert args[0] is agent.agent
+    assert args[1] == [{"role": "user", "content": "What is the weather in London?"}]
+    assert result is not None
+    assert result.final_output == "The weather in London is sunny"


### PR DESCRIPTION
- Introduced AgentInputType as a TypedDict to define structured input for the agent.
- Modified the arun method to accept a list of AgentInputType, allowing for more flexible input handling.
- Updated tests to validate the new input structure and ensure correct functionality.