### PR TITLE
Add E2B Code Interpreter runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,6 @@ docs = [
     "mkdocs-material>=9.5.0",
     "mkdocstrings[python]>=0.26.0",
 ]
+tools = [
+    "e2b-code-interpreter>=2.4.1",
+]

--- a/src/agentor/runtime.py
+++ b/src/agentor/runtime.py
@@ -1,0 +1,17 @@
+from agentor.tools.shell import LocalShellCommandRequest
+
+
+class SandboxRuntime:
+    def __call__(self, code: str) -> str:
+        raise NotImplementedError("SandboxRuntime is not implemented")
+
+
+class E2BCodeInterpreterRuntime(SandboxRuntime):
+    def __init__(self, timeout: int | None = None):
+        from e2b_code_interpreter import Sandbox
+
+        self.sbx = Sandbox.create(timeout=timeout)
+
+    def __call__(self, request: LocalShellCommandRequest) -> str:
+        execution = self.sbx.run_code(request.command)
+        return execution.logs


### PR DESCRIPTION
- Introduced a new runtime class for E2B Code Interpreter, allowing execution of code within a sandbox environment.


```python
from agentor import Agentor
from agentor.tools import LocalShellTool
from agentor.runtime import E2BCodeInterpreterRuntime

sandbox_runtime = E2BCodeInterpreterRuntime()

agent = Agentor(
    name="Assistant",
    model="gemini/gemini-3-flash-preview",
    instructions="You can execute shell commands to inspect the repository. Keep responses concise and include command output when helpful. Use the shell tool.",
    tools=[LocalShellTool(sandbox_runtime)],
)

result = await agent.arun("How many files are in the current directory?")
print(result.final_output)
```