### PR TITLE
Refactor WeatherAPI to GetWeatherTool and enhance agent functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ pip install git+https://github.com/celestoai/agentor@main
 Build an Agent, connect external tools or MCP Server and serve as an API in just a few lines of code:
 
 ```python
-from agentor.tools import WeatherAPI
+from agentor.tools import GetWeatherTool
 from agentor import Agentor
 
 agent = Agentor(
     name="Weather Agent",
     model="gpt-5-mini",  # Use any LLM provider - gemini/gemini-2.5-pro or anthropic/claude-3.5
-    tools=[WeatherAPI()]
+    tools=[GetWeatherTool()]
 )
 result = agent.run("What is the weather in London?")  # Run the Agent
 print(result)

--- a/examples/durable_agent.py
+++ b/examples/durable_agent.py
@@ -1,10 +1,10 @@
 from agentor.durable import DurableAgent
-from agentor.tools import WeatherAPI
+from agentor.tools import GetWeatherTool
 
 
 def main():
     # Initialize the tool
-    weather_tool = WeatherAPI()
+    weather_tool = GetWeatherTool()
 
     # Initialize the agent
     agent = DurableAgent(

--- a/src/agentor/tools/__init__.py
+++ b/src/agentor/tools/__init__.py
@@ -12,7 +12,7 @@ from .postgres import PostgreSQLTool
 from .shell import LocalShellTool
 from .slack import SlackTool
 from .timezone import TimezoneTool
-from .weather import WeatherAPI
+from .weather import GetWeatherTool
 
 __all__ = [
     "BaseTool",
@@ -27,7 +27,7 @@ __all__ = [
     "PostgreSQLTool",
     "SlackTool",
     "TimezoneTool",
-    "WeatherAPI",
+    "GetWeatherTool",
     "WebSearchTool",
     "LocalShellTool",
     "CodeInterpreterTool",

--- a/src/agentor/tools/shell.py
+++ b/src/agentor/tools/shell.py
@@ -22,15 +22,24 @@ class LocalShellTool(BaseTool):
     def __init__(
         self,
         executor: Callable[[LocalShellCommandRequest], str] = None,
+        verbose: bool = False,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.executor = executor or _shell_executor
+        self.verbose = verbose
 
     @capability
     def run(self, request: LocalShellCommandRequest):
-        return self.executor(request)
+        if self.verbose:
+            print(
+                f"Running command: {request.command} in working directory: {request.working_directory or os.getcwd()}"
+            )
+        result = self.executor(request)
+        if self.verbose:
+            print(f"Command result: {result}")
+        return result
 
 
 def _shell_executor(request: LocalShellCommandRequest) -> str:

--- a/src/agentor/tools/weather.py
+++ b/src/agentor/tools/weather.py
@@ -6,13 +6,17 @@ import httpx
 from agentor.tools.base import BaseTool, capability
 
 
-class WeatherAPI(BaseTool):
+class GetWeatherTool(BaseTool):
     name = "weather"
     description = "Get current weather information for a location"
 
     def __init__(self, api_key: Optional[str] = None):
         if api_key is None:
             api_key = os.environ.get("WEATHER_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "An API key is required to use this tool. Create an account at https://www.weatherapi.com/ and get your API key."
+            )
         super().__init__(api_key)
 
     @capability

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -5,7 +5,7 @@ from agentor.mcp.server import LiteMCP
 from agentor.tools.base import BaseTool, capability
 from agentor.tools.calculator import CalculatorTool
 from agentor.tools.timezone import TimezoneTool
-from agentor.tools.weather import WeatherAPI
+from agentor.tools.weather import GetWeatherTool
 
 
 def test_base_tool_conversion():
@@ -64,7 +64,7 @@ def test_timezone_tool():
 def test_weather_tool_api_key():
     """Test WeatherAPI tool requires API key."""
     with patch.dict(os.environ, {"WEATHER_API_KEY": ""}):
-        weather = WeatherAPI()  # No key available
+        weather = GetWeatherTool()  # No key available
         result = weather.get_current_weather("London")
 
     assert "Error: API key is required" in result
@@ -90,7 +90,7 @@ def test_weather_tool_mock_api():
         }
         mock_client.get.return_value = mock_response
 
-        weather = WeatherAPI(api_key="test-key")
+        weather = GetWeatherTool(api_key="test-key")
         result = weather.get_current_weather("London")
 
         assert "London" in result


### PR DESCRIPTION
- Renamed WeatherAPI to GetWeatherTool for clarity and consistency across the codebase.
- Updated examples and README to reflect the new tool name.
- Introduced a method to inject skills into the agent's instructions, improving agent capabilities.
- Increased the maximum turns for agent interactions from 10 to 20.
- Enhanced LocalShellTool to support verbose logging for command execution.
- Updated tests to use GetWeatherTool and validate API key requirements.