### PR TITLE
Exclude LiteLLM 1.82.7 and 1.82.8 from dependency range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "google-auth>=2.40.3",
     "googleapis-common-protos>=1.70.0",
     "typeguard>=4.4.4",
-    "litellm>=1.78.0",
+    "litellm>=1.78.0,!=1.82.7,!=1.82.8",
     "jinja2>=3.1.6",
     "openai-agents>=0.3.3",
     "superauth>=0.0.1",


### PR DESCRIPTION
### Motivation
- Prevent installation of known-malicious LiteLLM releases `1.82.7` and `1.82.8` by explicitly excluding them while preserving the existing `>=1.78.0` constraint.

### Description
- Update `pyproject.toml` to change the `litellm` dependency from `litellm>=1.78.0` to `litellm>=1.78.0,!=1.82.7,!=1.82.8`.

### Testing
- Verified the change with `rg -n "litellm" pyproject.toml` and parsed `pyproject.toml` using Python `tomllib`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41b020818832893a68c0196bcbae5)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted supply-chain security hardening: it excludes the known-malicious LiteLLM releases `1.82.7` and `1.82.8` from the dependency range while preserving the existing `>=1.78.0` floor. The single-line change is syntactically correct PEP 440 and will be respected by both pip and uv.

**Key changes:**
- `pyproject.toml`: `litellm>=1.78.0` → `litellm>=1.78.0,!=1.82.7,!=1.82.8`

**Potential follow-up:**
- `1.82.6` was reportedly part of the same malicious release batch; it may also need to be excluded (see inline comment). Confirm against the upstream advisory before merging.

<h3>Confidence Score: 4/5</h3>

- Safe to merge once the potential omission of `1.82.6` from the exclusion list is confirmed or ruled out.
- The change is minimal, syntactically correct, and addresses a real supply-chain risk. The only open question is whether `1.82.6` should also be excluded — if it doesn't need to be, the PR is ready to merge as-is.
- No files require special attention beyond confirming the `1.82.6` exclusion question in `pyproject.toml`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds `!=1.82.7,!=1.82.8` exclusions to the `litellm` dependency constraint to block known-malicious releases; syntax is valid PEP 440. Version `1.82.6` may also be malicious and is not excluded. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pip / uv resolve litellm] --> B{version >= 1.78.0?}
    B -- No --> C[Rejected]
    B -- Yes --> D{version == 1.82.7?}
    D -- Yes --> C
    D -- No --> E{version == 1.82.8?}
    E -- Yes --> C
    E -- No --> F[Accepted & Installed]
```

<sub>Reviews (1): Last reviewed commit: ["Exclude compromised LiteLLM versions"](https://github.com/celestoai/agentor/commit/69f49764ea044a458163579f23a1bf50931aca10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26338037)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->