### PR TITLE
feat: add Google Calendar tool

### DIFF
--- a/examples/tools/google_calendar.py
+++ b/examples/tools/google_calendar.py
@@ -1,5 +1,6 @@
 import os
 
+from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 
@@ -22,7 +23,17 @@ def get_calendar_credentials():
     if os.path.exists(CREDS_FILE):
         print(f"Loading credentials from {CREDS_FILE}")
         creds = Credentials.from_authorized_user_file(CREDS_FILE)
-        return creds
+        if creds.valid:
+            return creds
+
+        if creds.expired and creds.refresh_token:
+            print("Refreshing expired credentials...")
+            creds.refresh(Request())
+            with open(CREDS_FILE, "w") as f:
+                f.write(creds.to_json())
+            return creds
+
+        print("Saved credentials are invalid. Re-running OAuth consent flow...")
 
     # First time: Need OAuth setup
     print("No credentials found. Opening browser for authentication...")

--- a/examples/tools/google_calendar.py
+++ b/examples/tools/google_calendar.py
@@ -1,0 +1,88 @@
+import os
+
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+from agentor import Agentor
+from agentor.tools import CalendarTool
+
+CREDS_FILE = "credentials.json"
+SCOPES = ["https://www.googleapis.com/auth/calendar"]
+
+
+def get_calendar_credentials():
+    """
+    Get Google Calendar credentials.
+
+    On first run: Opens browser for user to approve access (one-time only)
+    On subsequent runs: Loads saved credentials from file
+    """
+
+    # If credentials already saved, load and return
+    if os.path.exists(CREDS_FILE):
+        print(f"Loading credentials from {CREDS_FILE}")
+        creds = Credentials.from_authorized_user_file(CREDS_FILE)
+        return creds
+
+    # First time: Need OAuth setup
+    print("No credentials found. Opening browser for authentication...")
+    print("(This only happens once)\n")
+
+    client_id = os.getenv("GOOGLE_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        raise ValueError(
+            "Environment variables not set:\n"
+            "   export GOOGLE_CLIENT_ID=your_client_id\n"
+            "   export GOOGLE_CLIENT_SECRET=your_client_secret\n\n"
+            "Get these from: https://console.cloud.google.com/"
+        )
+
+    # Create OAuth flow with server credentials
+    flow = InstalledAppFlow.from_client_config(
+        {
+            "installed": {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "redirect_uris": ["http://localhost:8000"],
+            }
+        },
+        scopes=SCOPES,
+    )
+
+    # Opens browser automatically, user approves, credentials returned
+    print("Browser opening... Please click 'Allow' to authenticate\n")
+    creds = flow.run_local_server(port=8000)
+
+    # Save credentials for future use
+    with open(CREDS_FILE, "w") as f:
+        f.write(creds.to_json())
+
+    print("Authentication successful!")
+    print(f"Credentials saved to: {CREDS_FILE}\n")
+
+    return creds
+
+
+def main() -> None:
+    # Get credentials (auto-handles OAuth on first run)
+    creds = get_calendar_credentials()
+
+    # Create agent with calendar tool
+    agent = Agentor(
+        name="Calendar Agent",
+        model="gpt-4o-mini",
+        tools=[CalendarTool(credentials=creds)],
+        instructions="Use the calendar tool to help with scheduling and event management.",
+    )
+
+    # Example request
+    result = agent.run("What events do I have tomorrow?")
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tools/google_calendar.py
+++ b/examples/tools/google_calendar.py
@@ -1,5 +1,6 @@
 import os
 
+from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -28,10 +29,14 @@ def get_calendar_credentials():
 
         if creds.expired and creds.refresh_token:
             print("Refreshing expired credentials...")
-            creds.refresh(Request())
-            with open(CREDS_FILE, "w") as f:
-                f.write(creds.to_json())
-            return creds
+            try:
+                creds.refresh(Request())
+                with open(CREDS_FILE, "w") as f:
+                    f.write(creds.to_json())
+                return creds
+            except RefreshError as exc:
+                print(f"Failed to refresh credentials: {exc}")
+                print("Re-running OAuth consent flow...")
 
         print("Saved credentials are invalid. Re-running OAuth consent flow...")
 

--- a/examples/tools/google_calendar.py
+++ b/examples/tools/google_calendar.py
@@ -154,7 +154,7 @@ def main() -> None:
     # Create agent with calendar tool
     agent = Agentor(
         name="Calendar Agent",
-        model="gpt-4o-mini",
+        model="gpt-5.4-mini",
         tools=[CalendarTool(credentials=creds)],
         instructions="Use the calendar tool to help with scheduling and event management.",
     )

--- a/examples/tools/google_calendar.py
+++ b/examples/tools/google_calendar.py
@@ -68,6 +68,7 @@ def get_calendar_credentials():
 
 
 def main() -> None:
+    """Run a sample calendar query using authenticated credentials."""
     # Get credentials (auto-handles OAuth on first run)
     creds = get_calendar_credentials()
 

--- a/examples/tools/google_calendar.py
+++ b/examples/tools/google_calendar.py
@@ -1,4 +1,9 @@
 import os
+import signal
+import socket
+import subprocess
+import time
+import json
 
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
@@ -12,6 +17,30 @@ CREDS_FILE = "credentials.json"
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 
+def _kill_port_8000():
+    """Kill any process using port 8000 to avoid 'Address already in use' errors."""
+    try:
+        # Use lsof to find process using port 8000
+        result = subprocess.run(
+            ["lsof", "-i", ":8000", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.stdout.strip():
+            pids = result.stdout.strip().split()
+            for pid in pids:
+                try:
+                    os.kill(int(pid), signal.SIGKILL)
+                except (ValueError, ProcessLookupError):
+                    pass
+        # Wait for OS to fully release the port
+        time.sleep(1)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # lsof not available or timeout - continue anyway
+        pass
+
+
 def get_calendar_credentials():
     """
     Get Google Calendar credentials.
@@ -23,22 +52,28 @@ def get_calendar_credentials():
     # If credentials already saved, load and return
     if os.path.exists(CREDS_FILE):
         print(f"Loading credentials from {CREDS_FILE}")
-        creds = Credentials.from_authorized_user_file(CREDS_FILE)
-        if creds.valid:
-            return creds
-
-        if creds.expired and creds.refresh_token:
-            print("Refreshing expired credentials...")
-            try:
-                creds.refresh(Request())
-                with open(CREDS_FILE, "w") as f:
-                    f.write(creds.to_json())
+        try:
+            creds = Credentials.from_authorized_user_file(CREDS_FILE)
+            if creds.valid:
                 return creds
-            except RefreshError as exc:
-                print(f"Failed to refresh credentials: {exc}")
-                print("Re-running OAuth consent flow...")
 
-        print("Saved credentials are invalid. Re-running OAuth consent flow...")
+            if creds.expired and creds.refresh_token:
+                print("Refreshing expired credentials...")
+                try:
+                    creds.refresh(Request())
+                    with open(CREDS_FILE, "w") as f:
+                        f.write(creds.to_json())
+                    return creds
+                except RefreshError as exc:
+                    print(f"Failed to refresh credentials: {exc}")
+                    print("Re-running OAuth consent flow...")
+            else:
+                print("Saved credentials are invalid. Re-running OAuth consent flow...")
+        except ValueError as e:
+            print(f"Credentials file is invalid: {e}")
+            print("Removing invalid credentials file...")
+            os.remove(CREDS_FILE)
+            print("Re-running OAuth consent flow...")
 
     # First time: Need OAuth setup
     print("No credentials found. Opening browser for authentication...")
@@ -71,9 +106,37 @@ def get_calendar_credentials():
 
     # Opens browser automatically, user approves, credentials returned
     print("Browser opening... Please click 'Allow' to authenticate\n")
-    creds = flow.run_local_server(port=8000)
+    # Kill any existing process on port 8000
+    _kill_port_8000()
+    
+    # Retry loop for port binding (in case OS hasn't fully released it)
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            # Request offline access to get refresh_token
+            creds = flow.run_local_server(port=8000, access_type="offline", prompt="consent")
+            break
+        except OSError as e:
+            if attempt < max_retries - 1:
+                print(f"Port binding failed (attempt {attempt + 1}/{max_retries}): {e}")
+                print("Retrying in 2 seconds...")
+                time.sleep(2)
+                _kill_port_8000()
+            else:
+                raise
 
     # Save credentials for future use
+    print("\nVerifying credentials...")
+    creds_data = json.loads(creds.to_json())
+    
+    if "refresh_token" not in creds_data or not creds_data.get("refresh_token"):
+        print("⚠️  Warning: No refresh token received. This might be because:")
+        print("  - You previously granted access to this app")
+        print("  - Google didn't include a refresh token in this flow")
+        print("\nTrying to get refresh token by requesting re-consent...")
+        print("Please delete credentials.json and run again to complete OAuth with offline access.\n")
+        # Still save what we have
+    
     with open(CREDS_FILE, "w") as f:
         f.write(creds.to_json())
 

--- a/src/agentor/tools/__init__.py
+++ b/src/agentor/tools/__init__.py
@@ -14,6 +14,7 @@ from .scrapegraphai import ScrapeGraphAI
 from .slack import SlackTool
 from .timezone import TimezoneTool
 from .weather import GetWeatherTool
+from .google_calendar import CalendarTool
 
 __all__ = [
     "BaseTool",
@@ -32,4 +33,5 @@ __all__ = [
     "GetWeatherTool",
     "WebSearchTool",
     "ShellTool",
+    "CalendarTool",
 ]

--- a/src/agentor/tools/google_calendar.py
+++ b/src/agentor/tools/google_calendar.py
@@ -57,11 +57,20 @@ class CalendarTool(BaseTool):
 
     @staticmethod
     def _normalize_datetime(dt_string: str) -> str:
-        """Ensure datetime has timezone info (append 'Z' for UTC if missing)."""
-        if dt_string and not (
-            dt_string.endswith("Z") or "+" in dt_string or "-" in dt_string[-6:]
-        ):
-            return dt_string + "Z"
+        """Validate datetime includes an explicit timezone offset."""
+        if not dt_string:
+            raise ValueError("Datetime is required and must include timezone.")
+
+        try:
+            parsed = datetime.fromisoformat(dt_string.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(
+                "Invalid datetime format. Use ISO 8601 with timezone (Z or ±HH:MM)."
+            ) from exc
+
+        if parsed.tzinfo is None:
+            raise ValueError("Datetime must include timezone (Z or ±HH:MM).")
+
         return dt_string
 
     @staticmethod
@@ -98,9 +107,9 @@ class CalendarTool(BaseTool):
         query: Optional[str] = None,
     ) -> str:
         """List events in a time window."""
-        start_time = self._normalize_datetime(start_time)
-        end_time = self._normalize_datetime(end_time)
         try:
+            start_time = self._normalize_datetime(start_time)
+            end_time = self._normalize_datetime(end_time)
             events_result = (
                 self.service.events()
                 .list(
@@ -115,6 +124,8 @@ class CalendarTool(BaseTool):
                 .execute()
             )
             return json.dumps(events_result.get("items", []))
+        except ValueError as exc:
+            return f"Error: {exc}"
         except Exception as exc:
             logger.exception("Calendar list_events error")
             return f"Error: {exc}"
@@ -133,10 +144,10 @@ class CalendarTool(BaseTool):
         if not title:
             return "Error: title is required."
 
-        start_time = self._normalize_datetime(start_time)
-        end_time = self._normalize_datetime(end_time)
-
         try:
+            start_time = self._normalize_datetime(start_time)
+            end_time = self._normalize_datetime(end_time)
+
             event = {
                 "summary": title,
                 "description": description or "",
@@ -151,6 +162,8 @@ class CalendarTool(BaseTool):
                 .execute()
             )
             return json.dumps(created)
+        except ValueError as exc:
+            return f"Error: {exc}"
         except Exception as exc:
             logger.exception("Calendar create_event error")
             return f"Error: {exc}"
@@ -165,10 +178,10 @@ class CalendarTool(BaseTool):
         limit: int = 10,
     ) -> str:
         """Find free time slots."""
-        start_time = self._normalize_datetime(start_time)
-        end_time = self._normalize_datetime(end_time)
-
         try:
+            start_time = self._normalize_datetime(start_time)
+            end_time = self._normalize_datetime(end_time)
+
             raw = self.list_events(
                 start_time=start_time,
                 end_time=end_time,
@@ -215,6 +228,8 @@ class CalendarTool(BaseTool):
                     "free_slots": free_slots[:limit],
                 }
             )
+        except ValueError as exc:
+            return f"Error: {exc}"
         except Exception as exc:
             logger.exception("Calendar find_free_slots error")
             return f"Error: {exc}"

--- a/src/agentor/tools/google_calendar.py
+++ b/src/agentor/tools/google_calendar.py
@@ -1,0 +1,277 @@
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+from agentor.tools.base import BaseTool, capability
+
+try:
+    from googleapiclient.discovery import build
+except ImportError:  # pragma: no cover - optional dependency
+    build = None
+
+logger = logging.getLogger(__name__)
+
+
+class CalendarTool(BaseTool):
+    name = "calendar"
+    description = (
+        "Google Calendar helper for listing, creating events, and finding free slots."
+    )
+
+    def __init__(self, credentials, api_key: Optional[str] = None):
+        """
+        Initialize the Calendar tool.
+
+        Args:
+            credentials: Google Credentials object (from user's stored token).
+                        Can be loaded from database and reconstructed using:
+                        from google.oauth2.credentials import Credentials
+                        creds = Credentials.from_authorized_user_info(creds_dict)
+            api_key: Optional API key for MCP use.
+        """
+        super().__init__(api_key)
+
+        if build is None:
+            raise ImportError(
+                "Google API client not installed. Install with: "
+                "pip install google-api-python-client"
+            )
+
+        if credentials is None:
+            raise ValueError(
+                "Credentials object is required. "
+                "For SaaS, pass pre-loaded credentials from user's stored token."
+            )
+
+        self.service = build("calendar", "v3", credentials=credentials)
+
+    @staticmethod
+    def _clamp_limit(limit: int, *, default: int = 20, max_limit: int = 100) -> int:
+        try:
+            value = int(limit)
+        except (TypeError, ValueError):
+            return default
+        return max(1, min(value, max_limit))
+
+    @staticmethod
+    def _normalize_datetime(dt_string: str) -> str:
+        """Ensure datetime has timezone info (append 'Z' for UTC if missing)."""
+        if dt_string and not (
+            dt_string.endswith("Z") or "+" in dt_string or "-" in dt_string[-6:]
+        ):
+            return dt_string + "Z"
+        return dt_string
+
+    @capability
+    def list_events(
+        self,
+        start_time: str,
+        end_time: str,
+        calendar_id: str = "primary",
+        limit: int = 20,
+        query: Optional[str] = None,
+    ) -> str:
+        """List events in a time window."""
+        start_time = self._normalize_datetime(start_time)
+        end_time = self._normalize_datetime(end_time)
+        try:
+            events_result = (
+                self.service.events()
+                .list(
+                    calendarId=calendar_id,
+                    timeMin=start_time,
+                    timeMax=end_time,
+                    maxResults=self._clamp_limit(limit),
+                    singleEvents=True,
+                    orderBy="startTime",
+                    q=query,
+                )
+                .execute()
+            )
+            return json.dumps(events_result.get("items", []))
+        except Exception as exc:
+            logger.exception("Calendar list_events error")
+            return f"Error: {exc}"
+
+    @capability
+    def create_event(
+        self,
+        title: str,
+        start_time: str,
+        end_time: str,
+        calendar_id: str = "primary",
+        description: Optional[str] = None,
+        location: Optional[str] = None,
+    ) -> str:
+        """Create a calendar event."""
+        if not title:
+            return "Error: title is required."
+
+        start_time = self._normalize_datetime(start_time)
+        end_time = self._normalize_datetime(end_time)
+
+        try:
+            event = {
+                "summary": title,
+                "description": description or "",
+                "location": location or "",
+                "start": {"dateTime": start_time},
+                "end": {"dateTime": end_time},
+            }
+
+            created = (
+                self.service.events()
+                .insert(calendarId=calendar_id, body=event)
+                .execute()
+            )
+            return json.dumps(created)
+        except Exception as exc:
+            logger.exception("Calendar create_event error")
+            return f"Error: {exc}"
+
+    @capability
+    def find_free_slots(
+        self,
+        start_time: str,
+        end_time: str,
+        meeting_minutes: int = 30,
+        calendar_id: str = "primary",
+        limit: int = 10,
+    ) -> str:
+        """Find free time slots."""
+        start_time = self._normalize_datetime(start_time)
+        end_time = self._normalize_datetime(end_time)
+
+        try:
+            raw = self.list_events(
+                start_time=start_time,
+                end_time=end_time,
+                calendar_id=calendar_id,
+                limit=250,
+            )
+
+            if raw.startswith("Error:"):
+                return raw
+
+            events = json.loads(raw)
+            busy_ranges = []
+
+            for event in events:
+                start = event.get("start", {}).get("dateTime")
+                end = event.get("end", {}).get("dateTime")
+                if start and end:
+                    busy_ranges.append((start, end))
+
+            busy_ranges.sort()
+
+            start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
+            free_slots = []
+            cursor = start_dt
+            needed = timedelta(minutes=meeting_minutes)
+
+            for busy_start_str, busy_end_str in busy_ranges:
+                busy_start = datetime.fromisoformat(
+                    busy_start_str.replace("Z", "+00:00")
+                )
+                if (busy_start - cursor) >= needed:
+                    free_slots.append(
+                        {"start": cursor.isoformat(), "end": busy_start.isoformat()}
+                    )
+                cursor = max(
+                    cursor, datetime.fromisoformat(busy_end_str.replace("Z", "+00:00"))
+                )
+
+            if (end_dt - cursor) >= needed:
+                free_slots.append(
+                    {"start": cursor.isoformat(), "end": end_dt.isoformat()}
+                )
+
+            return json.dumps(
+                {
+                    "window_start": start_time,
+                    "window_end": end_time,
+                    "meeting_minutes": meeting_minutes,
+                    "free_slots": free_slots[:limit],
+                }
+            )
+        except Exception as exc:
+            logger.exception("Calendar find_free_slots error")
+            return f"Error: {exc}"
+
+    @capability
+    def delete_event(
+        self,
+        event_id: str,
+        calendar_id: str = "primary",
+    ) -> str:
+        """Delete a calendar event."""
+        if not event_id:
+            return "Error: event_id is required."
+
+        try:
+            self.service.events().delete(
+                calendarId=calendar_id, eventId=event_id
+            ).execute()
+            return json.dumps(
+                {
+                    "status": "success",
+                    "message": f"Event {event_id} deleted successfully.",
+                }
+            )
+        except Exception as exc:
+            logger.exception("Calendar delete_event error")
+            return f"Error: {exc}"
+
+    @capability
+    def add_guests(
+        self,
+        event_id: str,
+        guest_emails: list,
+        calendar_id: str = "primary",
+        send_notifications: bool = True,
+    ) -> str:
+        """Add guests to a calendar event."""
+        if not event_id:
+            return "Error: event_id is required."
+        if not guest_emails or not isinstance(guest_emails, list):
+            return "Error: guest_emails must be a non-empty list."
+
+        try:
+            event = (
+                self.service.events()
+                .get(calendarId=calendar_id, eventId=event_id)
+                .execute()
+            )
+
+            existing_emails = {att.get("email") for att in event.get("attendees", [])}
+
+            attendees = event.get("attendees", [])
+            for email in guest_emails:
+                if email not in existing_emails:
+                    attendees.append({"email": email})
+
+            event["attendees"] = attendees
+            updated = (
+                self.service.events()
+                .update(
+                    calendarId=calendar_id,
+                    eventId=event_id,
+                    body=event,
+                    sendUpdates="all" if send_notifications else "none",
+                )
+                .execute()
+            )
+
+            return json.dumps(
+                {
+                    "status": "success",
+                    "message": f"Added {len(guest_emails)} guest(s) to event.",
+                    "event_id": updated.get("id"),
+                    "attendees": updated.get("attendees", []),
+                }
+            )
+        except Exception as exc:
+            logger.exception("Calendar add_guests error")
+            return f"Error: {exc}"

--- a/src/agentor/tools/google_calendar.py
+++ b/src/agentor/tools/google_calendar.py
@@ -2,6 +2,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from agentor.tools.base import BaseTool, capability
 
@@ -73,8 +74,26 @@ class CalendarTool(BaseTool):
 
         return dt_string
 
+    def _get_calendar_timezone(self, calendar_id: str = "primary") -> str:
+        """Get the timezone configured for a calendar.
+
+        Args:
+            calendar_id: Calendar ID (default "primary").
+
+        Returns:
+            IANA timezone string (e.g., "America/New_York").
+        """
+        try:
+            calendar = self.service.calendarList().get(calendarId=calendar_id).execute()
+            return calendar.get("timeZone", "UTC")
+        except Exception:
+            logger.debug(f"Failed to fetch timezone for {calendar_id}, defaulting to UTC")
+            return "UTC"
+
     @staticmethod
-    def _event_bounds(event: dict) -> tuple[datetime, datetime] | None:
+    def _event_bounds(
+        event: dict, calendar_timezone: str = "UTC"
+    ) -> tuple[datetime, datetime] | None:
         """Extract normalized event time bounds from timed or all-day events."""
         start_info = event.get("start", {})
         end_info = event.get("end", {})
@@ -90,9 +109,10 @@ class CalendarTool(BaseTool):
         start_date = start_info.get("date")
         end_date = end_info.get("date")
         if start_date and end_date:
+            tz = ZoneInfo(calendar_timezone)
             return (
-                datetime.fromisoformat(f"{start_date}T00:00:00+00:00"),
-                datetime.fromisoformat(f"{end_date}T00:00:00+00:00"),
+                datetime.fromisoformat(f"{start_date}T00:00:00").replace(tzinfo=tz),
+                datetime.fromisoformat(f"{end_date}T00:00:00").replace(tzinfo=tz),
             )
 
         return None
@@ -106,24 +126,43 @@ class CalendarTool(BaseTool):
         limit: int = 20,
         query: Optional[str] = None,
     ) -> str:
-        """List events in a time window."""
+        """List events in a time window.
+
+        Follows nextPageToken to fetch all events across pages.
+        """
         try:
             start_time = self._normalize_datetime(start_time)
             end_time = self._normalize_datetime(end_time)
-            events_result = (
-                self.service.events()
-                .list(
-                    calendarId=calendar_id,
-                    timeMin=start_time,
-                    timeMax=end_time,
-                    maxResults=self._clamp_limit(limit, max_limit=2500),
-                    singleEvents=True,
-                    orderBy="startTime",
-                    q=query,
+
+            all_items = []
+            page_token = None
+            max_results = self._clamp_limit(limit, max_limit=2500)
+
+            # Fetch pages until we have limit items or run out of pages
+            while len(all_items) < limit:
+                events_result = (
+                    self.service.events()
+                    .list(
+                        calendarId=calendar_id,
+                        timeMin=start_time,
+                        timeMax=end_time,
+                        maxResults=max_results,
+                        singleEvents=True,
+                        orderBy="startTime",
+                        q=query,
+                        pageToken=page_token,
+                    )
+                    .execute()
                 )
-                .execute()
-            )
-            return json.dumps(events_result.get("items", []))
+
+                all_items.extend(events_result.get("items", []))
+                page_token = events_result.get("nextPageToken")
+
+                if not page_token:
+                    # No more pages available
+                    break
+
+            return json.dumps(all_items[:limit])
         except ValueError as exc:
             return f"Error: {exc}"
         except Exception as exc:
@@ -202,10 +241,11 @@ class CalendarTool(BaseTool):
                 return raw
 
             events = json.loads(raw)
+            calendar_timezone = self._get_calendar_timezone(calendar_id)
             busy_ranges: list[tuple[datetime, datetime]] = []
 
             for event in events:
-                bounds = self._event_bounds(event)
+                bounds = self._event_bounds(event, calendar_timezone)
                 if bounds:
                     busy_ranges.append(bounds)
 

--- a/src/agentor/tools/google_calendar.py
+++ b/src/agentor/tools/google_calendar.py
@@ -182,6 +182,15 @@ class CalendarTool(BaseTool):
             start_time = self._normalize_datetime(start_time)
             end_time = self._normalize_datetime(end_time)
 
+            if meeting_minutes <= 0:
+                raise ValueError("meeting_minutes must be greater than 0.")
+
+            start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
+
+            if end_dt <= start_dt:
+                raise ValueError("end_time must be after start_time.")
+
             raw = self.list_events(
                 start_time=start_time,
                 end_time=end_time,
@@ -202,8 +211,6 @@ class CalendarTool(BaseTool):
 
             busy_ranges.sort(key=lambda span: span[0])
 
-            start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
-            end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
             free_slots = []
             cursor = start_dt
             needed = timedelta(minutes=meeting_minutes)
@@ -286,6 +293,7 @@ class CalendarTool(BaseTool):
             for email in guest_emails:
                 if email not in existing_emails:
                     attendees.append({"email": email})
+                    existing_emails.add(email)
                     added_count += 1
 
             event["attendees"] = attendees

--- a/src/agentor/tools/google_calendar.py
+++ b/src/agentor/tools/google_calendar.py
@@ -48,6 +48,7 @@ class CalendarTool(BaseTool):
 
     @staticmethod
     def _clamp_limit(limit: int, *, default: int = 20, max_limit: int = 100) -> int:
+        """Clamp list limits to a safe integer range."""
         try:
             value = int(limit)
         except (TypeError, ValueError):
@@ -89,6 +90,7 @@ class CalendarTool(BaseTool):
                 )
                 .execute()
             )
+            """Run a sample calendar query using authenticated credentials."""
             return json.dumps(events_result.get("items", []))
         except Exception as exc:
             logger.exception("Calendar list_events error")

--- a/src/agentor/tools/google_calendar.py
+++ b/src/agentor/tools/google_calendar.py
@@ -64,6 +64,30 @@ class CalendarTool(BaseTool):
             return dt_string + "Z"
         return dt_string
 
+    @staticmethod
+    def _event_bounds(event: dict) -> tuple[datetime, datetime] | None:
+        """Extract normalized event time bounds from timed or all-day events."""
+        start_info = event.get("start", {})
+        end_info = event.get("end", {})
+
+        start_dt = start_info.get("dateTime")
+        end_dt = end_info.get("dateTime")
+        if start_dt and end_dt:
+            return (
+                datetime.fromisoformat(start_dt.replace("Z", "+00:00")),
+                datetime.fromisoformat(end_dt.replace("Z", "+00:00")),
+            )
+
+        start_date = start_info.get("date")
+        end_date = end_info.get("date")
+        if start_date and end_date:
+            return (
+                datetime.fromisoformat(f"{start_date}T00:00:00+00:00"),
+                datetime.fromisoformat(f"{end_date}T00:00:00+00:00"),
+            )
+
+        return None
+
     @capability
     def list_events(
         self,
@@ -83,14 +107,13 @@ class CalendarTool(BaseTool):
                     calendarId=calendar_id,
                     timeMin=start_time,
                     timeMax=end_time,
-                    maxResults=self._clamp_limit(limit),
+                    maxResults=self._clamp_limit(limit, max_limit=2500),
                     singleEvents=True,
                     orderBy="startTime",
                     q=query,
                 )
                 .execute()
             )
-            """Run a sample calendar query using authenticated credentials."""
             return json.dumps(events_result.get("items", []))
         except Exception as exc:
             logger.exception("Calendar list_events error")
@@ -157,15 +180,14 @@ class CalendarTool(BaseTool):
                 return raw
 
             events = json.loads(raw)
-            busy_ranges = []
+            busy_ranges: list[tuple[datetime, datetime]] = []
 
             for event in events:
-                start = event.get("start", {}).get("dateTime")
-                end = event.get("end", {}).get("dateTime")
-                if start and end:
-                    busy_ranges.append((start, end))
+                bounds = self._event_bounds(event)
+                if bounds:
+                    busy_ranges.append(bounds)
 
-            busy_ranges.sort()
+            busy_ranges.sort(key=lambda span: span[0])
 
             start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
             end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
@@ -173,17 +195,12 @@ class CalendarTool(BaseTool):
             cursor = start_dt
             needed = timedelta(minutes=meeting_minutes)
 
-            for busy_start_str, busy_end_str in busy_ranges:
-                busy_start = datetime.fromisoformat(
-                    busy_start_str.replace("Z", "+00:00")
-                )
+            for busy_start, busy_end in busy_ranges:
                 if (busy_start - cursor) >= needed:
                     free_slots.append(
                         {"start": cursor.isoformat(), "end": busy_start.isoformat()}
                     )
-                cursor = max(
-                    cursor, datetime.fromisoformat(busy_end_str.replace("Z", "+00:00"))
-                )
+                cursor = max(cursor, busy_end)
 
             if (end_dt - cursor) >= needed:
                 free_slots.append(
@@ -250,9 +267,11 @@ class CalendarTool(BaseTool):
             existing_emails = {att.get("email") for att in event.get("attendees", [])}
 
             attendees = event.get("attendees", [])
+            added_count = 0
             for email in guest_emails:
                 if email not in existing_emails:
                     attendees.append({"email": email})
+                    added_count += 1
 
             event["attendees"] = attendees
             updated = (
@@ -269,7 +288,7 @@ class CalendarTool(BaseTool):
             return json.dumps(
                 {
                     "status": "success",
-                    "message": f"Added {len(guest_emails)} guest(s) to event.",
+                    "message": f"Added {added_count} guest(s) to event.",
                     "event_id": updated.get("id"),
                     "attendees": updated.get("attendees", []),
                 }

--- a/tests/tools/test_google_calendar.py
+++ b/tests/tools/test_google_calendar.py
@@ -6,6 +6,7 @@ from agentor.tools.google_calendar import CalendarTool
 
 
 def _mock_calendar_service():
+    """Return a mocked Google Calendar service with default responses."""
     service = MagicMock()
     events = service.events.return_value
 
@@ -41,6 +42,7 @@ def _mock_calendar_service():
 class TestGoogleCalendarTool(unittest.TestCase):
     @patch("agentor.tools.google_calendar.build")
     def test_init_requires_credentials(self, mock_build):
+        """Ensure tool initialization fails when credentials are missing."""
         mock_build.return_value = _mock_calendar_service()
         with self.assertRaises(ValueError) as ctx:
             CalendarTool(credentials=None)
@@ -48,6 +50,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_list_events_success_and_datetime_normalization(self, mock_build):
+        """Verify list_events returns items and normalizes naive datetimes."""
         service = _mock_calendar_service()
         service.events.return_value.list.return_value.execute.return_value = {
             "items": [{"id": "1"}]
@@ -68,6 +71,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_list_events_error(self, mock_build):
+        """Verify list_events returns an error string on API failures."""
         service = _mock_calendar_service()
         service.events.return_value.list.return_value.execute.side_effect = Exception(
             "API error"
@@ -83,6 +87,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_create_event_requires_title(self, mock_build):
+        """Ensure create_event requires a non-empty title."""
         mock_build.return_value = _mock_calendar_service()
         tool = CalendarTool(credentials=object())
 
@@ -95,6 +100,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_create_event_success(self, mock_build):
+        """Verify create_event builds payload and returns created event."""
         service = _mock_calendar_service()
         mock_build.return_value = service
         tool = CalendarTool(credentials=object())
@@ -116,6 +122,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_find_free_slots_success(self, mock_build):
+        """Verify free slot calculation returns at least one slot."""
         service = _mock_calendar_service()
         service.events.return_value.list.return_value.execute.return_value = {
             "items": [
@@ -139,6 +146,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_delete_event_validation_and_success(self, mock_build):
+        """Ensure delete_event validates input and deletes successfully."""
         service = _mock_calendar_service()
         mock_build.return_value = service
         tool = CalendarTool(credentials=object())
@@ -156,6 +164,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_add_guests_validation(self, mock_build):
+        """Ensure add_guests validates required arguments."""
         mock_build.return_value = _mock_calendar_service()
         tool = CalendarTool(credentials=object())
 
@@ -170,6 +179,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_add_guests_success_and_dedup(self, mock_build):
+        """Verify add_guests appends only new attendee emails."""
         service = _mock_calendar_service()
         mock_build.return_value = service
         tool = CalendarTool(credentials=object())
@@ -195,6 +205,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
     @patch("agentor.tools.google_calendar.build")
     def test_capabilities_registered(self, mock_build):
+        """Ensure all CalendarTool capabilities are exposed."""
         mock_build.return_value = _mock_calendar_service()
         tool = CalendarTool(credentials=object())
 

--- a/tests/tools/test_google_calendar.py
+++ b/tests/tools/test_google_calendar.py
@@ -49,8 +49,8 @@ class TestGoogleCalendarTool(unittest.TestCase):
         self.assertIn("Credentials object is required", str(ctx.exception))
 
     @patch("agentor.tools.google_calendar.build")
-    def test_list_events_success_and_datetime_normalization(self, mock_build):
-        """Verify list_events returns items and normalizes naive datetimes."""
+    def test_list_events_success_with_timezone_aware_datetimes(self, mock_build):
+        """Verify list_events works with timezone-aware datetime values."""
         service = _mock_calendar_service()
         service.events.return_value.list.return_value.execute.return_value = {
             "items": [{"id": "1"}]
@@ -59,8 +59,8 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
         tool = CalendarTool(credentials=object())
         result = tool.list_events(
-            start_time="2026-03-27T00:00:00",
-            end_time="2026-03-27T23:59:59",
+            start_time="2026-03-27T00:00:00Z",
+            end_time="2026-03-27T23:59:59Z",
         )
         parsed = json.loads(result)
         self.assertEqual(parsed, [{"id": "1"}])
@@ -68,6 +68,19 @@ class TestGoogleCalendarTool(unittest.TestCase):
         kwargs = service.events.return_value.list.call_args.kwargs
         self.assertEqual(kwargs["timeMin"], "2026-03-27T00:00:00Z")
         self.assertEqual(kwargs["timeMax"], "2026-03-27T23:59:59Z")
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_list_events_rejects_naive_datetimes(self, mock_build):
+        """Verify list_events rejects datetime values without timezone."""
+        mock_build.return_value = _mock_calendar_service()
+
+        tool = CalendarTool(credentials=object())
+        result = tool.list_events(
+            start_time="2026-03-27T00:00:00",
+            end_time="2026-03-27T23:59:59",
+        )
+
+        self.assertIn("Datetime must include timezone", result)
 
     @patch("agentor.tools.google_calendar.build")
     def test_list_events_allows_higher_limit_for_internal_queries(self, mock_build):
@@ -123,8 +136,8 @@ class TestGoogleCalendarTool(unittest.TestCase):
 
         result = tool.create_event(
             title="Team Sync",
-            start_time="2026-03-27T10:00:00",
-            end_time="2026-03-27T11:00:00",
+            start_time="2026-03-27T10:00:00Z",
+            end_time="2026-03-27T11:00:00Z",
             location="Zoom",
         )
         parsed = json.loads(result)
@@ -135,6 +148,20 @@ class TestGoogleCalendarTool(unittest.TestCase):
         self.assertEqual(kwargs["body"]["summary"], "Team Sync")
         self.assertTrue(kwargs["body"]["start"]["dateTime"].endswith("Z"))
         self.assertTrue(kwargs["body"]["end"]["dateTime"].endswith("Z"))
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_create_event_rejects_naive_datetimes(self, mock_build):
+        """Verify create_event rejects datetime values without timezone."""
+        mock_build.return_value = _mock_calendar_service()
+        tool = CalendarTool(credentials=object())
+
+        result = tool.create_event(
+            title="Team Sync",
+            start_time="2026-03-27T10:00:00",
+            end_time="2026-03-27T11:00:00",
+        )
+
+        self.assertIn("Datetime must include timezone", result)
 
     @patch("agentor.tools.google_calendar.build")
     def test_find_free_slots_success(self, mock_build):

--- a/tests/tools/test_google_calendar.py
+++ b/tests/tools/test_google_calendar.py
@@ -70,6 +70,22 @@ class TestGoogleCalendarTool(unittest.TestCase):
         self.assertEqual(kwargs["timeMax"], "2026-03-27T23:59:59Z")
 
     @patch("agentor.tools.google_calendar.build")
+    def test_list_events_allows_higher_limit_for_internal_queries(self, mock_build):
+        """Verify list_events supports higher limits used by free-slot scans."""
+        service = _mock_calendar_service()
+        mock_build.return_value = service
+
+        tool = CalendarTool(credentials=object())
+        tool.list_events(
+            start_time="2026-03-27T00:00:00Z",
+            end_time="2026-03-27T23:59:59Z",
+            limit=250,
+        )
+
+        kwargs = service.events.return_value.list.call_args.kwargs
+        self.assertEqual(kwargs["maxResults"], 250)
+
+    @patch("agentor.tools.google_calendar.build")
     def test_list_events_error(self, mock_build):
         """Verify list_events returns an error string on API failures."""
         service = _mock_calendar_service()
@@ -145,6 +161,29 @@ class TestGoogleCalendarTool(unittest.TestCase):
         self.assertGreaterEqual(len(parsed["free_slots"]), 1)
 
     @patch("agentor.tools.google_calendar.build")
+    def test_find_free_slots_handles_all_day_events(self, mock_build):
+        """Verify all-day events are treated as busy in free-slot search."""
+        service = _mock_calendar_service()
+        service.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "start": {"date": "2026-03-27"},
+                    "end": {"date": "2026-03-28"},
+                }
+            ]
+        }
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        result = tool.find_free_slots(
+            start_time="2026-03-27T09:00:00Z",
+            end_time="2026-03-27T12:00:00Z",
+            meeting_minutes=30,
+        )
+        parsed = json.loads(result)
+        self.assertEqual(parsed["free_slots"], [])
+
+    @patch("agentor.tools.google_calendar.build")
     def test_delete_event_validation_and_success(self, mock_build):
         """Ensure delete_event validates input and deletes successfully."""
         service = _mock_calendar_service()
@@ -192,6 +231,7 @@ class TestGoogleCalendarTool(unittest.TestCase):
         parsed = json.loads(result)
         self.assertEqual(parsed["status"], "success")
         self.assertEqual(parsed["event_id"], "evt-1")
+        self.assertEqual(parsed["message"], "Added 1 guest(s) to event.")
 
         update_kwargs = service.events.return_value.update.call_args.kwargs
         attendees = update_kwargs["body"]["attendees"]

--- a/tests/tools/test_google_calendar.py
+++ b/tests/tools/test_google_calendar.py
@@ -271,6 +271,48 @@ class TestGoogleCalendarTool(unittest.TestCase):
         self.assertEqual(update_kwargs["sendUpdates"], "none")
 
     @patch("agentor.tools.google_calendar.build")
+    def test_add_guests_dedup_duplicate_in_request(self, mock_build):
+        """Verify duplicate emails in guest_emails list appear only once."""
+        service = _mock_calendar_service()
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        result = tool.add_guests(
+            event_id="evt-1",
+            guest_emails=["dup@example.com", "dup@example.com"],
+            send_notifications=False,
+        )
+        parsed = json.loads(result)
+        self.assertEqual(parsed["status"], "success")
+        self.assertEqual(parsed["message"], "Added 1 guest(s) to event.")
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_find_free_slots_validates_meeting_minutes(self, mock_build):
+        """Verify find_free_slots rejects non-positive meeting_minutes."""
+        mock_build.return_value = _mock_calendar_service()
+        tool = CalendarTool(credentials=object())
+
+        result = tool.find_free_slots(
+            start_time="2026-03-27T09:00:00Z",
+            end_time="2026-03-27T12:00:00Z",
+            meeting_minutes=0,
+        )
+        self.assertIn("meeting_minutes must be greater than 0", result)
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_find_free_slots_validates_time_order(self, mock_build):
+        """Verify find_free_slots rejects when end_time <= start_time."""
+        mock_build.return_value = _mock_calendar_service()
+        tool = CalendarTool(credentials=object())
+
+        result = tool.find_free_slots(
+            start_time="2026-03-27T12:00:00Z",
+            end_time="2026-03-27T09:00:00Z",
+            meeting_minutes=30,
+        )
+        self.assertIn("end_time must be after start_time", result)
+
+    @patch("agentor.tools.google_calendar.build")
     def test_capabilities_registered(self, mock_build):
         """Ensure all CalendarTool capabilities are exposed."""
         mock_build.return_value = _mock_calendar_service()

--- a/tests/tools/test_google_calendar.py
+++ b/tests/tools/test_google_calendar.py
@@ -36,6 +36,13 @@ def _mock_calendar_service():
             {"email": "new@example.com"},
         ],
     }
+
+    # Mock calendarList for timezone retrieval
+    calendar_list = service.calendarList.return_value
+    calendar_list.get.return_value.execute.return_value = {
+        "timeZone": "UTC"
+    }
+
     return service
 
 
@@ -324,6 +331,79 @@ class TestGoogleCalendarTool(unittest.TestCase):
         self.assertIn("find_free_slots", fn_names)
         self.assertIn("delete_event", fn_names)
         self.assertIn("add_guests", fn_names)
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_list_events_follows_pagination(self, mock_build):
+        """Verify list_events fetches multiple pages with nextPageToken."""
+        service = _mock_calendar_service()
+
+        # Mock two pages: first with nextPageToken, second without
+        service.events.return_value.list.return_value.execute.side_effect = [
+            {
+                "items": [{"id": "evt-1"}, {"id": "evt-2"}],
+                "nextPageToken": "page2token",
+            },
+            {
+                "items": [{"id": "evt-3"}],
+                # No nextPageToken means last page
+            },
+        ]
+        mock_build.return_value = service
+
+        tool = CalendarTool(credentials=object())
+        result = tool.list_events(
+            start_time="2026-03-27T00:00:00Z",
+            end_time="2026-03-27T23:59:59Z",
+            limit=5,
+        )
+
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed), 3)
+        self.assertEqual(parsed[0]["id"], "evt-1")
+        self.assertEqual(parsed[2]["id"], "evt-3")
+
+        # Verify pageToken was passed correctly
+        calls = service.events.return_value.list.call_args_list
+        self.assertEqual(len(calls), 2)
+        # First call should have pageToken=None
+        self.assertIsNone(calls[0].kwargs.get("pageToken"))
+        # Second call should use the token from first response
+        self.assertEqual(calls[1].kwargs.get("pageToken"), "page2token")
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_find_free_slots_with_timezone_aware_all_day_events(self, mock_build):
+        """Verify all-day events are converted using calendar's actual timezone."""
+        service = _mock_calendar_service()
+
+        # Mock calendarList to return non-UTC timezone
+        service.calendarList.return_value.get.return_value.execute.return_value = {
+            "timeZone": "America/New_York"
+        }
+
+        # All-day event in America/New_York
+        service.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "start": {"date": "2026-03-27"},
+                    "end": {"date": "2026-03-28"},
+                }
+            ]
+        }
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        result = tool.find_free_slots(
+            start_time="2026-03-27T09:00:00-04:00",  # EDT offset
+            end_time="2026-03-27T12:00:00-04:00",
+            meeting_minutes=30,
+        )
+
+        parsed = json.loads(result)
+        # All-day event should consume the entire window
+        self.assertEqual(parsed["free_slots"], [])
+
+        # Verify calendarList was called to get timezone
+        service.calendarList.return_value.get.assert_called_with(calendarId="primary")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_google_calendar.py
+++ b/tests/tools/test_google_calendar.py
@@ -1,0 +1,210 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentor.tools.google_calendar import CalendarTool
+
+
+def _mock_calendar_service():
+    service = MagicMock()
+    events = service.events.return_value
+
+    # Default list response
+    events.list.return_value.execute.return_value = {"items": []}
+
+    # Default insert response
+    events.insert.return_value.execute.return_value = {
+        "id": "evt-1",
+        "summary": "Test Event",
+    }
+
+    # Default delete response
+    events.delete.return_value.execute.return_value = {}
+
+    # Default get response (used by add_guests)
+    events.get.return_value.execute.return_value = {
+        "id": "evt-1",
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    # Default update response
+    events.update.return_value.execute.return_value = {
+        "id": "evt-1",
+        "attendees": [
+            {"email": "existing@example.com"},
+            {"email": "new@example.com"},
+        ],
+    }
+    return service
+
+
+class TestGoogleCalendarTool(unittest.TestCase):
+    @patch("agentor.tools.google_calendar.build")
+    def test_init_requires_credentials(self, mock_build):
+        mock_build.return_value = _mock_calendar_service()
+        with self.assertRaises(ValueError) as ctx:
+            CalendarTool(credentials=None)
+        self.assertIn("Credentials object is required", str(ctx.exception))
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_list_events_success_and_datetime_normalization(self, mock_build):
+        service = _mock_calendar_service()
+        service.events.return_value.list.return_value.execute.return_value = {
+            "items": [{"id": "1"}]
+        }
+        mock_build.return_value = service
+
+        tool = CalendarTool(credentials=object())
+        result = tool.list_events(
+            start_time="2026-03-27T00:00:00",
+            end_time="2026-03-27T23:59:59",
+        )
+        parsed = json.loads(result)
+        self.assertEqual(parsed, [{"id": "1"}])
+
+        kwargs = service.events.return_value.list.call_args.kwargs
+        self.assertEqual(kwargs["timeMin"], "2026-03-27T00:00:00Z")
+        self.assertEqual(kwargs["timeMax"], "2026-03-27T23:59:59Z")
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_list_events_error(self, mock_build):
+        service = _mock_calendar_service()
+        service.events.return_value.list.return_value.execute.side_effect = Exception(
+            "API error"
+        )
+        mock_build.return_value = service
+
+        tool = CalendarTool(credentials=object())
+        result = tool.list_events(
+            start_time="2026-03-27T00:00:00Z",
+            end_time="2026-03-27T23:59:59Z",
+        )
+        self.assertIn("Error: API error", result)
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_create_event_requires_title(self, mock_build):
+        mock_build.return_value = _mock_calendar_service()
+        tool = CalendarTool(credentials=object())
+
+        result = tool.create_event(
+            title="",
+            start_time="2026-03-27T10:00:00Z",
+            end_time="2026-03-27T11:00:00Z",
+        )
+        self.assertEqual(result, "Error: title is required.")
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_create_event_success(self, mock_build):
+        service = _mock_calendar_service()
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        result = tool.create_event(
+            title="Team Sync",
+            start_time="2026-03-27T10:00:00",
+            end_time="2026-03-27T11:00:00",
+            location="Zoom",
+        )
+        parsed = json.loads(result)
+        self.assertEqual(parsed["id"], "evt-1")
+
+        kwargs = service.events.return_value.insert.call_args.kwargs
+        self.assertEqual(kwargs["calendarId"], "primary")
+        self.assertEqual(kwargs["body"]["summary"], "Team Sync")
+        self.assertTrue(kwargs["body"]["start"]["dateTime"].endswith("Z"))
+        self.assertTrue(kwargs["body"]["end"]["dateTime"].endswith("Z"))
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_find_free_slots_success(self, mock_build):
+        service = _mock_calendar_service()
+        service.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "start": {"dateTime": "2026-03-27T10:00:00Z"},
+                    "end": {"dateTime": "2026-03-27T11:00:00Z"},
+                }
+            ]
+        }
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        result = tool.find_free_slots(
+            start_time="2026-03-27T09:00:00Z",
+            end_time="2026-03-27T12:00:00Z",
+            meeting_minutes=30,
+        )
+        parsed = json.loads(result)
+        self.assertIn("free_slots", parsed)
+        self.assertGreaterEqual(len(parsed["free_slots"]), 1)
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_delete_event_validation_and_success(self, mock_build):
+        service = _mock_calendar_service()
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        self.assertEqual(tool.delete_event(event_id=""), "Error: event_id is required.")
+
+        result = tool.delete_event(event_id="evt-1")
+        parsed = json.loads(result)
+        self.assertEqual(parsed["status"], "success")
+
+        service.events.return_value.delete.assert_called_with(
+            calendarId="primary",
+            eventId="evt-1",
+        )
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_add_guests_validation(self, mock_build):
+        mock_build.return_value = _mock_calendar_service()
+        tool = CalendarTool(credentials=object())
+
+        self.assertEqual(
+            tool.add_guests(event_id="", guest_emails=["a@example.com"]),
+            "Error: event_id is required.",
+        )
+        self.assertIn(
+            "guest_emails must be a non-empty list",
+            tool.add_guests(event_id="evt-1", guest_emails=[]),
+        )
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_add_guests_success_and_dedup(self, mock_build):
+        service = _mock_calendar_service()
+        mock_build.return_value = service
+        tool = CalendarTool(credentials=object())
+
+        result = tool.add_guests(
+            event_id="evt-1",
+            guest_emails=["existing@example.com", "new@example.com"],
+            send_notifications=False,
+        )
+        parsed = json.loads(result)
+        self.assertEqual(parsed["status"], "success")
+        self.assertEqual(parsed["event_id"], "evt-1")
+
+        update_kwargs = service.events.return_value.update.call_args.kwargs
+        attendees = update_kwargs["body"]["attendees"]
+        emails = sorted([a["email"] for a in attendees])
+
+        self.assertEqual(
+            emails,
+            ["existing@example.com", "new@example.com"],
+        )
+        self.assertEqual(update_kwargs["sendUpdates"], "none")
+
+    @patch("agentor.tools.google_calendar.build")
+    def test_capabilities_registered(self, mock_build):
+        mock_build.return_value = _mock_calendar_service()
+        tool = CalendarTool(credentials=object())
+
+        fn_names = [fn.name for fn in tool.to_openai_function()]
+        self.assertIn("list_events", fn_names)
+        self.assertIn("create_event", fn_names)
+        self.assertIn("find_free_slots", fn_names)
+        self.assertIn("delete_event", fn_names)
+        self.assertIn("add_guests", fn_names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds a new Google Calendar integration to the project, providing a robust `CalendarTool` for interacting with Google Calendar via OAuth credentials. The integration includes capabilities for listing, creating, and deleting events, finding free time slots, and managing event guests. The PR also introduces comprehensive tests and an example usage script.

**Key changes include:**

**Google Calendar Tool Integration:**

* Added a new `CalendarTool` in `src/agentor/tools/google_calendar.py` that supports listing events, creating events, finding free slots, deleting events, and adding guests to events, all via Google Calendar API. The tool handles OAuth credentials, input validation, and error handling.
* Registered `CalendarTool` in the `src/agentor/tools/__init__.py` for use throughout the project. [[1]](diffhunk://#diff-91f807f279d852bdc1bbfa137d7d55691c2ea035908defe57e1373c7196b5ddbR17) [[2]](diffhunk://#diff-91f807f279d852bdc1bbfa137d7d55691c2ea035908defe57e1373c7196b5ddbR36)

**Example and Documentation:**

* Added an example script `examples/tools/google_calendar.py` that demonstrates how to authenticate with Google, instantiate the agent with the calendar tool, and run a sample query for upcoming events.

**Testing:**

* Introduced a comprehensive test suite in `tests/tools/test_google_calendar.py`, covering initialization, all tool capabilities, error handling, and OpenAI function registration, using mocks for the Google API client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Calendar integration: list events, create events, find free time slots, delete events, and add/manage attendees via a Calendar tool exposed to agents.
* **Examples**
  * Added an example demonstrating OAuth-based sign-in, credential persistence, and an end-to-end calendar query.
* **Tests**
  * New test suite validating calendar tool behavior, input validation, error handling, and capability exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `CalendarTool` backed by the Google Calendar API, covering listing events, creating events, finding free slots, deleting events, and managing guests. The tool follows the existing `BaseTool`/`@capability` pattern well, and the test suite covers the main code paths with clean mocks.

There are two correctness bugs in `find_free_slots` and a credential-lifecycle issue in the example that should be fixed before merge:

- **`find_free_slots` 100-event cap** — the internal call to `list_events(limit=250)` is silently clamped to 100 by `_clamp_limit`. For a busy calendar this causes later busy periods to be invisible, producing false free-slot results.
- **All-day events ignored in `find_free_slots`** — Google returns all-day events with a `date` key, not `dateTime`. The current code skips them, so an "Out of Office" all-day block is not treated as busy.
- **Credential expiry in the example** — saved credentials are returned without checking `creds.expired` or calling `creds.refresh(Request())`, so the example will fail with a 401 roughly 1 hour after the initial OAuth flow.
- **`add_guests` success message** — the message always reports the full number of emails passed, not the number actually appended after deduplication.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — two logic bugs in the primary find_free_slots capability can produce silently wrong results in normal usage

The 100-event cap and the all-day-event blind spot in find_free_slots are reproducible in ordinary use and return incorrect data without any error signal to the caller. These are not edge cases; any user with a moderately busy calendar or any all-day event in the window would be affected. The credential refresh omission makes the example non-functional after an hour.

src/agentor/tools/google_calendar.py (find_free_slots method, lines 147–198) and examples/tools/google_calendar.py (credential loading, lines 21–25)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/tools/google_calendar.py | Core tool implementation; contains two logic bugs in find_free_slots (100-event cap due to _clamp_limit, and all-day events silently skipped) that can produce incorrect free slot suggestions |
| examples/tools/google_calendar.py | Example authentication helper; missing credential refresh logic means the example fails with 401 after the initial access token expires (~1 hour) |
| src/agentor/tools/__init__.py | Straightforward registration of CalendarTool in the tools package; no issues |
| tests/tools/test_google_calendar.py | Good coverage of happy-path and validation cases; the find_free_slots test only covers a single event, so it does not catch the clamping or all-day-event blind spots |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant CalendarTool
    participant GoogleCalendarAPI

    Agent->>CalendarTool: find_free_slots(start, end, meeting_minutes)
    CalendarTool->>CalendarTool: _normalize_datetime(start/end)
    CalendarTool->>CalendarTool: list_events(start, end, limit=250)
    Note over CalendarTool: _clamp_limit(250) → 100 (bug!)
    CalendarTool->>GoogleCalendarAPI: events.list(maxResults=100)
    GoogleCalendarAPI-->>CalendarTool: items[] (only first 100 events)
    CalendarTool->>CalendarTool: parse busy_ranges (skips all-day events, bug!)
    CalendarTool->>CalendarTool: compute free_slots from gaps
    CalendarTool-->>Agent: JSON {free_slots}

    Agent->>CalendarTool: create_event(title, start, end, ...)
    CalendarTool->>CalendarTool: validate + normalize datetimes
    CalendarTool->>GoogleCalendarAPI: events.insert(body)
    GoogleCalendarAPI-->>CalendarTool: created event JSON
    CalendarTool-->>Agent: JSON event

    Agent->>CalendarTool: add_guests(event_id, guest_emails)
    CalendarTool->>GoogleCalendarAPI: events.get(eventId)
    GoogleCalendarAPI-->>CalendarTool: existing event with attendees
    CalendarTool->>CalendarTool: dedup + append new attendees
    CalendarTool->>GoogleCalendarAPI: events.update(body, sendUpdates)
    GoogleCalendarAPI-->>CalendarTool: updated event JSON
    CalendarTool-->>Agent: JSON {status, attendees}
```

<sub>Reviews (1): Last reviewed commit: ["feat: add Google Calendar tool"](https://github.com/celestoai/agentor/commit/09fcb62e06b1143322d6f88beee8dcfd74e10d7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26544518)</sub>

> Greptile also left **4 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->