### PR TITLE
feat(engine): native agent loop behind engine="native"

### DIFF
--- a/docs/dev/MIGRATION_PLAN.md
+++ b/docs/dev/MIGRATION_PLAN.md
@@ -182,13 +182,48 @@ The residual ~1.4s is openai-agents itself (1.19s, mostly `mcp` → `jsonschema`
 Fixing this also surfaced a latent circular import (`agentor.a2a` → `agentor.core` → `core.agent`
 → `agentor.a2a`) that the old eager `__init__` had been masking.
 
-### Phase 1 — Core loop behind the existing API (3–4 days)
+### Phase 1 — Core loop behind the existing API ✅ *shipped*
 
-Land `events.py`, `tool.py`, `model.py`, `loop.py`. Gate with `Agentor(engine="native")`,
-defaulting to the openai-agents path. Port the test suite to run against both engines.
+`agentor/engine/` — **917 LOC**, gated by `Agentor(engine="native")`, default still `"agents"`.
+Nothing in it imports openai-agents, so Phase 5 is a deletion rather than a rewrite.
 
-Carry over from the spike: per-tool failure budget, tool errors fed back as messages rather
-than raised, `max_turns` as a hard stop.
+| file | LOC | |
+|---|---|---|
+| `events.py` | 87 | `Event`, `RunResult`, `Usage` — the single description of a run |
+| `tools.py` | 260 | schema generation, docstring parsing, one `Tool` type |
+| `models.py` | 257 | `Model` protocol, `ChatCompletionsModel`, `LiteLLMModel` |
+| `loop.py` | 279 | the loop: sync/async/stream, budgets, model swap |
+
+**Measured:**
+
+| | agents engine | native engine |
+|---|---|---|
+| import | 1.124s | **0.047s** |
+| agent construction (5 tools) | 1.17 ms | 4.39 ms |
+
+Construction is ~3 ms slower because schemas are built with pydantic (`create_model` +
+`model_json_schema` is 0.176 ms of the 0.211 ms per tool). Deliberately not optimised: it is
+noise next to a 500 ms+ model call, and a cache would add invalidation logic for no visible gain.
+
+**Verified against the live API** (22/22 checks) and 30 unit tests driven by a scripted fake model:
+
+- Schema parity with openai-agents, **including param descriptions parsed from Google-style
+  docstrings**. Skipping those would have quietly degraded tool-calling accuracy.
+- `RunContextWrapper` is detected by name, excluded from the schema, and injected at call time,
+  so existing registry tools work unchanged — without importing openai-agents.
+- Parallel tool calls, streamed tool-call reassembly from fragmented deltas, usage accounting.
+- Tool errors are fed back to the model rather than raised; unknown tools and malformed JSON
+  arguments are reported, not fatal.
+- `stream_chat` projects engine events onto the existing `AgentOutput` wire format, so `serve()`,
+  `/chat` and the A2A handler are untouched.
+
+**The spike bug is fixed, and testing it found a second one.** A failing tool used to burn all 10
+turns; a failure budget now disables it after 2. The first fix only withdrew the tool's *schema* —
+but a model can still emit a call for a tool it was not offered, which let the broken tool keep
+running. The budget is now enforced at execution.
+
+Known gaps in `engine="native"`, all raising or deferred rather than silently ignored:
+MCP servers (raises `NotImplementedError`), `output_type` structured output, `WebSearchTool`.
 
 ### Phase 2 — One tool abstraction (2 days)
 

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 from agentor.a2a import A2AController, AgentSkill
 from agentor.config import celesto_config
-from agentor.output_text_formatter import AgentOutput, format_stream_events
+from agentor.output_text_formatter import AgentOutput, ToolAction, format_stream_events
 from agentor.prompts import THINKING_PROMPT, render_prompt
 from agentor.skills import Skills
 from agentor.tools.base import BaseTool
@@ -208,10 +208,27 @@ class Agentor(AgentorBase):
         model_settings: Optional[ModelSettings] = None,
         skills: Optional[List[str]] = None,
         enable_tracing: bool = False,
+        engine: Literal["agents", "native"] = "agents",
+        max_turns: int = 10,
     ):
         if skills is not None:
             available_skills = self._inject_skills(skills)
             instructions = f"{instructions or ''}\n\n{available_skills}"
+
+        self.engine = engine
+        if engine == "native":
+            self._init_native(
+                name=name,
+                instructions=instructions,
+                model=model,
+                tools=tools,
+                api_key=api_key,
+                model_settings=model_settings,
+                max_turns=max_turns,
+                enable_tracing=enable_tracing,
+            )
+            return
+
         super().__init__(name, instructions, model, api_key, enable_tracing)
         tools = tools or []
         resolved_tools: List[FunctionTool] = []
@@ -253,6 +270,77 @@ class Agentor(AgentorBase):
             output_type=output_type,
             model_settings=model_settings,
         )
+
+    def _init_native(
+        self,
+        name: str,
+        instructions: Optional[str],
+        model: Any,
+        tools: Optional[List[Any]],
+        api_key: Optional[str],
+        model_settings: Optional[ModelSettings],
+        max_turns: int,
+        enable_tracing: bool,
+    ) -> None:
+        """Set up the native engine (see agentor.engine)."""
+        from agentor.engine import AgentLoop
+        from agentor.engine.tools import resolve_tools
+
+        self.name = name
+        self.instructions = instructions
+        self.api_key = api_key
+        self.agent = None
+        self.mcp_servers = []
+        self.enable_tracing = enable_tracing
+        self._setup_tracing(enable_tracing)
+
+        for tool in tools or []:
+            if isinstance(tool, MCPServerStreamableHttp):
+                raise NotImplementedError(
+                    "MCP servers are not supported by engine='native' yet. "
+                    "Use engine='agents' for MCP-backed tools."
+                )
+
+        # Fail loudly rather than silently dropping a tool the caller passed.
+        self._tools = resolve_tools(tools)
+        self.tools = self._tools
+
+        params: Dict[str, Any] = {}
+        for field in ("temperature", "top_p", "max_tokens"):
+            value = getattr(model_settings, field, None)
+            if value is not None:
+                params[field] = value
+
+        self.model = model
+        self._loop = AgentLoop(
+            name=name,
+            model=model or "gpt-4o-mini",
+            instructions=instructions,
+            tools=self._tools,
+            context=CelestoConfig(),
+            max_turns=max_turns,
+            api_key=api_key,
+            **params,
+        )
+
+    def _setup_tracing(self, enable_tracing: bool) -> None:
+        """Tracing setup shared with AgentorBase, without the agents-only bits."""
+        if not enable_tracing and (
+            celesto_config.api_key is None or celesto_config.disable_auto_tracing
+        ):
+            return
+        if enable_tracing and not celesto_config.api_key:
+            raise ValueError(
+                "Celesto API key is required to enable tracing. "
+                "Find it at https://celesto.ai/dashboard and set CELESTO_API_KEY."
+            )
+        try:
+            setup_celesto_tracing(
+                endpoint=f"{celesto_config.base_url}/traces/ingest",
+                token=celesto_config.api_key.get_secret_value(),
+            )
+        except Exception as e:
+            logger.warning(f"Failed to setup Celesto tracing: {e}")
 
     def _inject_skills(self, skills: List[str]) -> str:
         """Inject skills into the agent system prompt."""
@@ -395,6 +483,8 @@ class Agentor(AgentorBase):
         )
 
     def run(self, input: str) -> List[str] | str:
+        if self.engine == "native":
+            return self._loop.run(input)
         return Runner.run_sync(self.agent, input, context=CelestoConfig())
 
     async def arun(
@@ -417,6 +507,8 @@ class Agentor(AgentorBase):
         """
         if isinstance(input, list):
             if isinstance(input[0], dict):
+                if self.engine == "native":
+                    return await self._loop.arun(input)
                 return await Runner.run(self.agent, input, context=CelestoConfig())
 
             futures = []
@@ -451,6 +543,9 @@ class Agentor(AgentorBase):
         """
         Run a task with optional fallback to alternative models on rate limit errors.
         """
+        if self.engine == "native":
+            return await self._run_native_with_fallback(task, fallback_models)
+
         retryable = _retryable_errors()
         try:
             return await Runner.run(
@@ -497,11 +592,43 @@ class Agentor(AgentorBase):
             # All fallback models failed, raise the original error
             raise
 
+    async def _run_native_with_fallback(
+        self, task: str, fallback_models: Optional[List[str]] = None
+    ):
+        """Native-engine equivalent of _run_with_fallback.
+
+        Swapping the model is a copy of the loop rather than a rebuilt agent,
+        because the model is not baked into the agent here.
+        """
+        retryable = _retryable_errors()
+        try:
+            return await self._loop.arun(task)
+        except retryable as e:
+            if not fallback_models:
+                raise
+            logger.warning(
+                f"Primary model failed with {type(e).__name__}: {e}. "
+                f"Trying fallback models: {fallback_models}"
+            )
+            for fallback_model in fallback_models:
+                try:
+                    return await self._loop.with_model(
+                        fallback_model, api_key=self.api_key
+                    ).arun(task)
+                except retryable as fallback_error:
+                    logger.warning(
+                        f"Fallback model '{fallback_model}' also failed: {fallback_error}"
+                    )
+                    continue
+            raise
+
     def think(self, query: str) -> List[str] | str:
         prompt = render_prompt(
             THINKING_PROMPT,
             query=query,
         )
+        if self.engine == "native":
+            return self._loop.run(prompt).final_output
         result = Runner.run_sync(self.agent, prompt, context=CelestoConfig())
         return result.final_output
 
@@ -513,6 +640,8 @@ class Agentor(AgentorBase):
     ):
         if stream:
             return self.stream_chat(input, serialize=serialize)
+        elif self.engine == "native":
+            return await self._loop.arun(input)
         else:
             return await Runner.run(self.agent, input=input, context=CelestoConfig())
 
@@ -521,15 +650,54 @@ class Agentor(AgentorBase):
         input: str,
         serialize: bool = True,
     ) -> AsyncIterator[Union[str, AgentOutput]]:
-        result = Runner.run_streamed(self.agent, input=input, context=CelestoConfig())
-        async for agent_output in format_stream_events(
-            result.stream_events(),
-            allowed_events=["run_item_stream_event"],
-        ):
+        if self.engine == "native":
+            stream = self._native_stream()(input)
+        else:
+            result = Runner.run_streamed(
+                self.agent, input=input, context=CelestoConfig()
+            )
+            stream = format_stream_events(
+                result.stream_events(),
+                allowed_events=["run_item_stream_event"],
+            )
+
+        async for agent_output in stream:
             if serialize:
                 yield agent_output.serialize(dump_json=True)
             else:
                 yield agent_output
+
+    def _native_stream(self):
+        """Project engine events onto AgentOutput.
+
+        Keeps `serve()`, the /chat endpoint and the A2A handler working against
+        one wire format regardless of which engine produced the run.
+        """
+
+        async def stream(input: str) -> AsyncIterator[AgentOutput]:
+            async for event in self._loop.astream(input):
+                if event.type == "message":
+                    yield AgentOutput(
+                        type="run_item_stream_event", message=event.text
+                    )
+                elif event.type == "tool_call":
+                    yield AgentOutput(
+                        type="run_item_stream_event",
+                        tool_action=ToolAction(name=event.name, type="tool_called"),
+                    )
+                elif event.type == "tool_result":
+                    yield AgentOutput(
+                        type="run_item_stream_event",
+                        message=event.result,
+                        tool_action=ToolAction(name=event.name, type="tool_output"),
+                    )
+                elif event.type == "run_end" and event.status != "completed":
+                    yield AgentOutput(
+                        type="run_item_stream_event",
+                        message=event.error or "Run did not complete.",
+                    )
+
+        return stream
 
     def serve(
         self,

--- a/src/agentor/engine/__init__.py
+++ b/src/agentor/engine/__init__.py
@@ -1,0 +1,34 @@
+"""Agentor's native agent engine.
+
+Self-contained by design: nothing here imports openai-agents, so removing that
+dependency in a later phase is a deletion rather than a rewrite.
+"""
+
+from agentor.engine.events import Event, RunResult, Usage
+from agentor.engine.loop import AgentLoop
+from agentor.engine.models import (
+    ChatCompletionsModel,
+    LiteLLMModel,
+    Model,
+    ModelResponse,
+    ToolCall,
+    resolve_model,
+)
+from agentor.engine.tools import Tool, build_schema, parse_docstring, resolve_tools
+
+__all__ = [
+    "AgentLoop",
+    "ChatCompletionsModel",
+    "Event",
+    "LiteLLMModel",
+    "Model",
+    "ModelResponse",
+    "RunResult",
+    "Tool",
+    "ToolCall",
+    "Usage",
+    "build_schema",
+    "parse_docstring",
+    "resolve_model",
+    "resolve_tools",
+]

--- a/src/agentor/engine/events.py
+++ b/src/agentor/engine/events.py
@@ -1,0 +1,87 @@
+"""Normalized events emitted by the agent loop.
+
+This is deliberately the *only* description of what happened during a run.
+Streaming, the final result, and the Celesto trace payload are all projections
+of this stream, so there is no second format to keep in sync.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+EventType = Literal[
+    "run_start",
+    "text_delta",
+    "message",
+    "tool_call",
+    "tool_result",
+    "run_end",
+    "error",
+]
+
+RunStatus = Literal["completed", "max_turns", "failed"]
+
+
+@dataclass
+class Usage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+    def __add__(self, other: "Usage") -> "Usage":
+        return Usage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
+
+
+@dataclass
+class Event:
+    type: EventType
+    #: assistant text: the full message for `message`, one chunk for `text_delta`
+    text: Optional[str] = None
+    #: tool name for `tool_call` / `tool_result`
+    name: Optional[str] = None
+    #: parsed tool arguments
+    args: Optional[Dict[str, Any]] = None
+    #: stringified tool return value
+    result: Optional[str] = None
+    #: set on `tool_result` when the tool raised, and on `error`
+    error: Optional[str] = None
+    #: links a tool_result back to its tool_call
+    call_id: Optional[str] = None
+    #: 1-based, so events can be grouped into turns without replaying the loop
+    turn: Optional[int] = None
+    usage: Optional[Usage] = None
+    status: Optional[RunStatus] = None
+    agent: Optional[str] = None
+    model: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), default=str)
+
+
+@dataclass
+class RunResult:
+    """Terminal state of a run. Carries the events that produced it."""
+
+    final_output: Optional[str] = None
+    status: RunStatus = "completed"
+    events: List[Event] = field(default_factory=list)
+    usage: Usage = field(default_factory=Usage)
+    #: full message list, suitable for feeding back in to continue the conversation
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def __str__(self) -> str:
+        return self.final_output or ""
+
+    @property
+    def tool_calls(self) -> List[Event]:
+        return [e for e in self.events if e.type == "tool_call"]

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -1,0 +1,279 @@
+"""The agent loop.
+
+Call the model; if it asked for tools, run them and feed the results back;
+repeat until it stops asking or a budget is hit. Everything the engine does
+is emitted as an `Event`, and `arun`/`run` are projections of `astream`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
+
+from agentor.engine.events import Event, RunResult, Usage
+from agentor.engine.models import Model, ModelResponse, ToolCall, resolve_model
+from agentor.engine.tools import Tool, resolve_tools
+
+logger = logging.getLogger(__name__)
+
+MessageInput = Union[str, List[Dict[str, Any]]]
+
+
+class AgentLoop:
+    """A single agent: a model, some tools, and the loop that drives them."""
+
+    def __init__(
+        self,
+        name: str = "Agent",
+        model: Any = "gpt-4o-mini",
+        instructions: Optional[str] = None,
+        tools: Optional[List[Any]] = None,
+        context: Any = None,
+        max_turns: int = 10,
+        max_tool_failures: int = 2,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **model_params: Any,
+    ):
+        self.name = name
+        self.instructions = instructions
+        self.context = context
+        self.max_turns = max_turns
+        self.max_tool_failures = max_tool_failures
+        self.model: Model = resolve_model(
+            model, api_key=api_key, base_url=base_url, **model_params
+        )
+        self.tools: Dict[str, Tool] = {t.name: t for t in resolve_tools(tools)}
+
+    def with_model(self, model: Any, **kwargs: Any) -> "AgentLoop":
+        """Copy this loop with a different model.
+
+        Cheap because the model is a separate object from the agent: tools are
+        already resolved and are shared, not rebuilt.
+        """
+        clone = object.__new__(AgentLoop)
+        clone.__dict__.update(self.__dict__)
+        clone.model = resolve_model(model, **kwargs)
+        return clone
+
+    # ------------------------------------------------------------ messages
+
+    def _initial_messages(self, input: MessageInput) -> List[Dict[str, Any]]:
+        messages: List[Dict[str, Any]] = []
+        if self.instructions:
+            messages.append({"role": "system", "content": self.instructions})
+        if isinstance(input, str):
+            messages.append({"role": "user", "content": input})
+        else:
+            messages.extend(input)
+        return messages
+
+    @staticmethod
+    def _assistant_message(response: ModelResponse) -> Dict[str, Any]:
+        message: Dict[str, Any] = {"role": "assistant", "content": response.content}
+        if response.tool_calls:
+            message["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.name, "arguments": tc.arguments},
+                }
+                for tc in response.tool_calls
+            ]
+        return message
+
+    def _schemas(self, disabled: set[str]) -> Optional[List[Dict[str, Any]]]:
+        schemas = [
+            t.to_openai() for name, t in self.tools.items() if name not in disabled
+        ]
+        return schemas or None
+
+    # ------------------------------------------------------------ execution
+
+    async def _run_tool(
+        self, call: ToolCall, disabled: set[str] = frozenset()
+    ) -> Event:
+        try:
+            args = json.loads(call.arguments or "{}")
+        except json.JSONDecodeError as exc:
+            return Event(
+                type="tool_result",
+                name=call.name,
+                call_id=call.id,
+                error=f"Invalid JSON arguments: {exc}",
+                result=f"Error: arguments were not valid JSON ({exc}).",
+            )
+
+        if call.name in disabled:
+            # Withdrawing the schema is not enough on its own: a model can still
+            # emit a call for a tool it was not offered, which would let a
+            # broken tool run past its budget.
+            return Event(
+                type="tool_result",
+                name=call.name,
+                args=args,
+                call_id=call.id,
+                error="tool disabled",
+                result=f"Error: tool {call.name!r} is disabled after repeated failures.",
+            )
+
+        tool = self.tools.get(call.name)
+        if tool is None:
+            known = ", ".join(sorted(self.tools)) or "none"
+            return Event(
+                type="tool_result",
+                name=call.name,
+                args=args,
+                call_id=call.id,
+                error="unknown tool",
+                result=f"Error: unknown tool {call.name!r}. Available tools: {known}.",
+            )
+
+        try:
+            result = await tool.call(args, context=self.context)
+            return Event(
+                type="tool_result",
+                name=call.name,
+                args=args,
+                call_id=call.id,
+                result=result,
+            )
+        except Exception as exc:
+            # Surfaced to the model rather than raised: a failing tool is
+            # usually recoverable, and the failure budget stops it looping.
+            logger.warning("Tool %s failed: %s", call.name, exc, exc_info=True)
+            return Event(
+                type="tool_result",
+                name=call.name,
+                args=args,
+                call_id=call.id,
+                error=f"{type(exc).__name__}: {exc}",
+                result=f"Error: {type(exc).__name__}: {exc}",
+            )
+
+    # ------------------------------------------------------------ the loop
+
+    async def astream(
+        self, input: MessageInput, stream_text: bool = False
+    ) -> AsyncIterator[Event]:
+        messages = self._initial_messages(input)
+        failures: Dict[str, int] = {}
+        disabled: set[str] = set()
+        total = Usage()
+
+        yield Event(
+            type="run_start",
+            agent=self.name,
+            model=getattr(self.model, "model", None),
+        )
+
+        for turn in range(1, self.max_turns + 1):
+            schemas = self._schemas(disabled)
+
+            if stream_text:
+                response = None
+                async for chunk in self.model.stream(messages, schemas):
+                    if chunk.delta:
+                        yield Event(type="text_delta", text=chunk.delta, turn=turn)
+                    if chunk.final is not None:
+                        response = chunk.final
+                if response is None:
+                    response = ModelResponse()
+            else:
+                response = await self.model.complete(messages, schemas)
+
+            total = total + response.usage
+            messages.append(self._assistant_message(response))
+
+            if not response.tool_calls:
+                text = response.content or ""
+                yield Event(type="message", text=text, turn=turn, usage=response.usage)
+                yield Event(
+                    type="run_end",
+                    text=text,
+                    status="completed",
+                    usage=total,
+                    turn=turn,
+                )
+                return
+
+            for call in response.tool_calls:
+                try:
+                    preview = json.loads(call.arguments or "{}")
+                except json.JSONDecodeError:
+                    preview = None
+                yield Event(
+                    type="tool_call",
+                    name=call.name,
+                    args=preview,
+                    call_id=call.id,
+                    turn=turn,
+                )
+
+            results = await asyncio.gather(
+                *(self._run_tool(call, disabled) for call in response.tool_calls)
+            )
+
+            for event in results:
+                event.turn = turn
+                yield event
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": event.call_id,
+                        "content": event.result or "",
+                    }
+                )
+
+                if (
+                    event.error is None
+                    or event.name not in self.tools
+                    or event.name in disabled
+                ):
+                    continue
+
+                failures[event.name] = failures.get(event.name, 0) + 1
+                if failures[event.name] >= self.max_tool_failures:
+                    # Retrying a tool that keeps failing just burns turns. Drop
+                    # it and let the model finish with what is left.
+                    disabled.add(event.name)
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                f"The tool '{event.name}' failed "
+                                f"{failures[event.name]} times and is now "
+                                "unavailable. Answer without it, or explain "
+                                "what you cannot do."
+                            ),
+                        }
+                    )
+
+        yield Event(
+            type="run_end",
+            status="max_turns",
+            error=f"Reached max_turns ({self.max_turns}) without a final answer.",
+            usage=total,
+        )
+
+    async def arun(self, input: MessageInput) -> RunResult:
+        result = RunResult()
+        async for event in self.astream(input):
+            result.events.append(event)
+            if event.type == "run_end":
+                result.status = event.status or "completed"
+                result.final_output = event.text
+                result.usage = event.usage or Usage()
+                result.error = event.error
+        return result
+
+    def run(self, input: MessageInput) -> RunResult:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.arun(input))
+        raise RuntimeError(
+            "run() cannot be called from a running event loop; await arun() instead."
+        )

--- a/src/agentor/engine/models.py
+++ b/src/agentor/engine/models.py
@@ -1,0 +1,257 @@
+"""Model adapters.
+
+Only one shape is needed to reach almost every provider: an OpenAI-compatible
+`/chat/completions` endpoint. Anthropic, Gemini, Groq, Together, OpenRouter,
+Fireworks, DeepSeek, xAI, Mistral, vLLM and Ollama all expose one, so pointing
+`base_url` at them is enough. litellm stays available for the long tail.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, List, Optional, Protocol, runtime_checkable
+
+from agentor.engine.events import Usage
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    #: raw JSON string, exactly as the model emitted it
+    arguments: str = ""
+
+
+@dataclass
+class ModelResponse:
+    content: Optional[str] = None
+    tool_calls: List[ToolCall] = field(default_factory=list)
+    usage: Usage = field(default_factory=Usage)
+    #: provider payload, for tracing
+    raw: Any = None
+
+
+@dataclass
+class StreamChunk:
+    """One streamed step. `final` is set only on the last chunk."""
+
+    delta: Optional[str] = None
+    final: Optional[ModelResponse] = None
+
+
+@runtime_checkable
+class Model(Protocol):
+    async def complete(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+    ) -> ModelResponse: ...
+
+    def stream(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+    ) -> AsyncIterator[StreamChunk]: ...
+
+
+def _usage(raw: Any) -> Usage:
+    usage = getattr(raw, "usage", None)
+    if usage is None:
+        return Usage()
+    return Usage(
+        input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+        output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+        total_tokens=getattr(usage, "total_tokens", 0) or 0,
+    )
+
+
+class ChatCompletionsModel:
+    """Any OpenAI-compatible chat-completions endpoint."""
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        client: Any = None,
+        **params: Any,
+    ):
+        self.model = model
+        self.params = params
+
+        if client is not None:
+            self.client = client
+        else:
+            from openai import AsyncOpenAI
+
+            self.client = AsyncOpenAI(
+                api_key=api_key or os.environ.get("OPENAI_API_KEY"),
+                base_url=base_url,
+            )
+
+    def _request(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]]
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            **self.params,
+        }
+        if tools:
+            payload["tools"] = tools
+        return payload
+
+    async def complete(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+    ) -> ModelResponse:
+        raw = await self.client.chat.completions.create(
+            **self._request(messages, tools)
+        )
+        message = raw.choices[0].message
+        return ModelResponse(
+            content=message.content,
+            tool_calls=[
+                ToolCall(
+                    id=tc.id,
+                    name=tc.function.name,
+                    arguments=tc.function.arguments or "",
+                )
+                for tc in (message.tool_calls or [])
+            ],
+            usage=_usage(raw),
+            raw=raw,
+        )
+
+    async def stream(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+    ) -> AsyncIterator[StreamChunk]:
+        request = self._request(messages, tools)
+        request["stream"] = True
+        request["stream_options"] = {"include_usage": True}
+
+        content: List[str] = []
+        # Tool calls arrive fragmented and out of order; `index` is the only
+        # reliable key, and id/name may appear in a later chunk than the first
+        # for that index.
+        partial: Dict[int, Dict[str, str]] = {}
+        usage = Usage()
+
+        try:
+            stream = await self.client.chat.completions.create(**request)
+        except TypeError:
+            # Some OpenAI-compatible servers reject stream_options.
+            request.pop("stream_options", None)
+            stream = await self.client.chat.completions.create(**request)
+
+        async for event in stream:
+            if getattr(event, "usage", None):
+                usage = _usage(event)
+            if not event.choices:
+                continue
+
+            delta = event.choices[0].delta
+            if delta is None:
+                continue
+
+            if delta.content:
+                content.append(delta.content)
+                yield StreamChunk(delta=delta.content)
+
+            for tc in delta.tool_calls or []:
+                slot = partial.setdefault(
+                    tc.index, {"id": "", "name": "", "arguments": ""}
+                )
+                if tc.id:
+                    slot["id"] = tc.id
+                if tc.function and tc.function.name:
+                    slot["name"] = tc.function.name
+                if tc.function and tc.function.arguments:
+                    slot["arguments"] += tc.function.arguments
+
+        yield StreamChunk(
+            final=ModelResponse(
+                content="".join(content) or None,
+                tool_calls=[
+                    ToolCall(id=s["id"], name=s["name"], arguments=s["arguments"])
+                    for _, s in sorted(partial.items())
+                ],
+                usage=usage,
+            )
+        )
+
+
+class LiteLLMModel:
+    """Escape hatch for providers with no OpenAI-compatible endpoint.
+
+    Kept behind a lazy import so it costs nothing unless used.
+    """
+
+    def __init__(self, model: str, api_key: Optional[str] = None, **params: Any):
+        self.model = model
+        self.api_key = api_key
+        self.params = params
+
+    async def complete(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+    ) -> ModelResponse:
+        import litellm
+
+        raw = await litellm.acompletion(
+            model=self.model,
+            messages=messages,
+            tools=tools or None,
+            api_key=self.api_key,
+            **self.params,
+        )
+        message = raw.choices[0].message
+        return ModelResponse(
+            content=message.content,
+            tool_calls=[
+                ToolCall(
+                    id=tc.id,
+                    name=tc.function.name,
+                    arguments=tc.function.arguments or "",
+                )
+                for tc in (getattr(message, "tool_calls", None) or [])
+            ],
+            usage=_usage(raw),
+            raw=raw,
+        )
+
+    async def stream(
+        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+    ) -> AsyncIterator[StreamChunk]:
+        # litellm mirrors the OpenAI streaming shape, so reuse that accumulator
+        # rather than maintaining a second one.
+        import litellm
+
+        model = ChatCompletionsModel.__new__(ChatCompletionsModel)
+        model.model = self.model
+        model.params = self.params
+
+        class _Shim:
+            class chat:
+                class completions:
+                    @staticmethod
+                    async def create(**kwargs):
+                        kwargs.pop("stream_options", None)
+                        return await litellm.acompletion(api_key=self.api_key, **kwargs)
+
+        model.client = _Shim()
+        async for chunk in model.stream(messages, tools):
+            yield chunk
+
+
+def resolve_model(
+    model: Any,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    **params: Any,
+) -> Model:
+    """Turn a user-supplied model into a `Model`.
+
+    A `provider/name` string routes to litellm, matching what the openai-agents
+    engine does today, so existing model strings keep working.
+    """
+    if isinstance(model, str):
+        if "/" in model and base_url is None:
+            return LiteLLMModel(model, api_key=api_key, **params)
+        return ChatCompletionsModel(model, api_key=api_key, base_url=base_url, **params)
+    return model

--- a/src/agentor/engine/tools.py
+++ b/src/agentor/engine/tools.py
@@ -1,0 +1,260 @@
+"""Tool definition and JSON-schema generation for the native engine.
+
+One `Tool` type, built from whatever the caller already has: a plain function,
+a `BaseTool` capability, an openai-agents `FunctionTool`, or a registry name.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, get_type_hints
+
+from pydantic import create_model
+
+# Matches "name: description" or "name (type): description" inside an Args:
+# block, which is the Google style used across agentor's own tools.
+_ARG_LINE = re.compile(r"^\s*(\*{0,2}\w+)\s*(?:\([^)]*\))?\s*:\s*(.+)$")
+_SECTION = re.compile(
+    r"^\s*(Args|Arguments|Parameters|Returns|Raises|Yields|Examples?|Notes?)\s*:\s*$",
+    re.IGNORECASE,
+)
+
+
+def parse_docstring(doc: Optional[str]) -> tuple[str, Dict[str, str]]:
+    """Split a docstring into (summary, {param: description}).
+
+    Supports the Google style used by agentor's tools. Param descriptions
+    matter: without them the model gets a bare type and guesses more.
+    """
+    if not doc:
+        return "", {}
+
+    lines = inspect.cleandoc(doc).splitlines()
+    summary: List[str] = []
+    params: Dict[str, str] = {}
+    section: Optional[str] = None
+    current: Optional[str] = None
+
+    for line in lines:
+        header = _SECTION.match(line)
+        if header:
+            section = header.group(1).lower()
+            current = None
+            continue
+
+        if section in ("args", "arguments", "parameters"):
+            match = _ARG_LINE.match(line)
+            if match:
+                current = match.group(1).lstrip("*")
+                params[current] = match.group(2).strip()
+            elif current and line.strip():
+                # continuation of the previous parameter's description
+                params[current] += " " + line.strip()
+        elif section is None:
+            summary.append(line)
+
+    return "\n".join(summary).strip(), params
+
+
+def _strip_titles(schema: Any) -> Any:
+    """Drop pydantic's auto-generated `title` keys.
+
+    They carry no meaning for tool calling and are sent on every request.
+    """
+    if isinstance(schema, dict):
+        return {
+            k: _strip_titles(v)
+            for k, v in schema.items()
+            if k != "title" or not isinstance(v, str)
+        }
+    if isinstance(schema, list):
+        return [_strip_titles(item) for item in schema]
+    return schema
+
+
+def _is_context_param(annotation: Any) -> bool:
+    """True for openai-agents' RunContextWrapper, matched by name.
+
+    Matching the name rather than importing keeps this module free of an
+    openai-agents dependency, so the engine survives that package's removal.
+    """
+    return "RunContextWrapper" in str(annotation)
+
+
+def build_schema(
+    fn: Callable, skip: Optional[set[str]] = None
+) -> tuple[str, Dict[str, Any], Optional[str]]:
+    """Derive (description, json_schema, context_param) from a callable."""
+    skip = set(skip or ())
+    summary, param_docs = parse_docstring(inspect.getdoc(fn))
+
+    try:
+        hints = get_type_hints(fn, include_extras=True)
+    except Exception:
+        # Unresolvable forward refs shouldn't make a tool unusable.
+        hints = getattr(fn, "__annotations__", {}) or {}
+
+    context_param: Optional[str] = None
+    fields: Dict[str, Any] = {}
+
+    for name, param in inspect.signature(fn).parameters.items():
+        if name in ("self", "cls") or name in skip:
+            continue
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+
+        annotation = hints.get(name, str)
+        if context_param is None and _is_context_param(annotation):
+            context_param = name
+            continue
+
+        default = ... if param.default is inspect.Parameter.empty else param.default
+        fields[name] = (annotation, default)
+
+    model = create_model(f"{getattr(fn, '__name__', 'tool')}_args", **fields)
+    schema = _strip_titles(model.model_json_schema())
+    schema.setdefault("properties", {})
+    schema.setdefault("required", [])
+
+    for name, description in param_docs.items():
+        prop = schema["properties"].get(name)
+        if isinstance(prop, dict) and "description" not in prop:
+            prop["description"] = description
+
+    return summary, schema, context_param
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+    invoke: Callable[..., Any]
+    #: parameter that receives the run context instead of model-supplied args
+    context_param: Optional[str] = None
+
+    def to_openai(self) -> Dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+    async def call(self, args: Dict[str, Any], context: Any = None) -> str:
+        kwargs = dict(args)
+        if self.context_param:
+            kwargs[self.context_param] = _ContextWrapper(context)
+
+        result = self.invoke(**kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return stringify(result)
+
+    @classmethod
+    def from_function(
+        cls,
+        fn: Callable,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> "Tool":
+        summary, schema, context_param = build_schema(fn)
+        return cls(
+            name=name or getattr(fn, "__name__", "tool"),
+            description=description or summary,
+            parameters=schema,
+            invoke=fn,
+            context_param=context_param,
+        )
+
+
+class _ContextWrapper:
+    """Minimal stand-in for openai-agents' RunContextWrapper.
+
+    Legacy tools declare `wrapper: RunContextWrapper[CelestoConfig]` and read
+    `wrapper.context`; supporting that attribute is the whole compatibility
+    surface. Phase 2 removes the need for this.
+    """
+
+    __slots__ = ("context",)
+
+    def __init__(self, context: Any = None):
+        self.context = context
+
+
+def stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if hasattr(value, "model_dump"):
+        try:
+            return json.dumps(value.model_dump(), default=str)
+        except Exception:
+            pass
+    if isinstance(value, (dict, list, tuple, int, float, bool)):
+        try:
+            return json.dumps(value, default=str)
+        except Exception:
+            pass
+    return str(value)
+
+
+def _from_function_tool(ft: Any) -> Tool:
+    """Adapt an openai-agents FunctionTool.
+
+    Its `on_invoke_tool(ctx, args_json)` takes a JSON string, so arguments are
+    re-serialized on the way in.
+    """
+    invoker = ft.on_invoke_tool
+
+    async def invoke(**kwargs: Any) -> Any:
+        return await invoker(_ContextWrapper(None), json.dumps(kwargs))
+
+    return Tool(
+        name=ft.name,
+        description=ft.description or "",
+        parameters=_strip_titles(dict(ft.params_json_schema or {})),
+        invoke=invoke,
+    )
+
+
+def resolve_tools(tools: Optional[List[Any]]) -> List[Tool]:
+    """Normalize anything tool-shaped into a list of `Tool`."""
+    from agentor.tools.base import BaseTool
+
+    resolved: List[Tool] = []
+    for item in tools or []:
+        if isinstance(item, Tool):
+            resolved.append(item)
+
+        elif isinstance(item, str):
+            from agentor.tools.registry import ToolRegistry
+
+            entry = ToolRegistry.get(item)
+            # The registry stores the undecorated function alongside the
+            # openai-agents tool; the raw function is what we want.
+            resolved.append(Tool.from_function(entry["function"], name=item))
+
+        elif isinstance(item, BaseTool):
+            for attr_name, method in item.list_capabilities():
+                resolved.append(Tool.from_function(method, name=attr_name))
+
+        elif callable(item) and hasattr(item, "on_invoke_tool"):
+            resolved.append(_from_function_tool(item))
+
+        elif callable(item):
+            resolved.append(Tool.from_function(item))
+
+        else:
+            raise TypeError(
+                f"Unsupported tool type {type(item).__name__!r}. Expected a "
+                "callable, a Tool, a BaseTool, a FunctionTool, or a registry name."
+            )
+
+    return resolved

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,453 @@
+"""Tests for the native engine (agentor.engine).
+
+The loop is exercised against a scripted fake model so behaviour is asserted
+without network access.
+"""
+
+from typing import Literal, Optional
+
+import pytest
+
+from agentor.engine import AgentLoop, Tool, resolve_tools
+from agentor.engine.events import Usage
+from agentor.engine.models import ModelResponse, StreamChunk, ToolCall
+from agentor.engine.tools import build_schema, parse_docstring
+from agentor.tools.base import BaseTool, capability
+
+# --------------------------------------------------------------- fake model
+
+
+class FakeModel:
+    """Replays a scripted list of ModelResponses and records what it was sent."""
+
+    model = "fake-model"
+
+    def __init__(self, *responses: ModelResponse):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, tools=None):
+        self.calls.append({"messages": [dict(m) for m in messages], "tools": tools})
+        if not self.responses:
+            return ModelResponse(content="done")
+        return self.responses.pop(0)
+
+    async def stream(self, messages, tools=None):
+        response = await self.complete(messages, tools)
+        for piece in (response.content or "").split(" "):
+            yield StreamChunk(delta=piece + " ")
+        yield StreamChunk(final=response)
+
+
+def text(content):
+    return ModelResponse(content=content, usage=Usage(1, 2, 3))
+
+
+def calls(*specs):
+    return ModelResponse(
+        tool_calls=[
+            ToolCall(id=f"c{i}", name=name, arguments=args)
+            for i, (name, args) in enumerate(specs)
+        ],
+        usage=Usage(1, 2, 3),
+    )
+
+
+# --------------------------------------------------------------- docstrings
+
+
+def test_parse_docstring_google_style():
+    summary, params = parse_docstring(
+        """Do a thing.
+
+        Args:
+            a: First value.
+            b (int): Second value,
+                continued on the next line.
+
+        Returns:
+            Something.
+        """
+    )
+    assert summary == "Do a thing."
+    assert params["a"] == "First value."
+    assert params["b"] == "Second value, continued on the next line."
+
+
+def test_parse_docstring_empty():
+    assert parse_docstring(None) == ("", {})
+    assert parse_docstring("") == ("", {})
+
+
+def test_build_schema_types_and_descriptions():
+    def fn(city: str, unit: Literal["c", "f"] = "c", days: Optional[int] = None):
+        """Look up weather.
+
+        Args:
+            city: Which city.
+            unit: Temperature unit.
+        """
+
+    description, schema, context_param = build_schema(fn)
+
+    assert description == "Look up weather."
+    assert context_param is None
+    assert schema["required"] == ["city"]
+    assert schema["properties"]["unit"]["enum"] == ["c", "f"]
+    assert schema["properties"]["city"]["description"] == "Which city."
+    # titles are pydantic noise and are sent on every request
+    assert "title" not in schema["properties"]["city"]
+
+
+def test_build_schema_detects_context_param():
+    def fn(wrapper: "RunContextWrapper[str]", city: str):  # noqa: F821
+        """Doc."""
+
+    _, schema, context_param = build_schema(fn)
+    assert context_param == "wrapper"
+    assert list(schema["properties"]) == ["city"]
+
+
+# --------------------------------------------------------------- tool resolve
+
+
+def test_resolve_plain_function():
+    def greet(name: str) -> str:
+        """Greet someone."""
+        return f"hi {name}"
+
+    (tool,) = resolve_tools([greet])
+    assert tool.name == "greet"
+    assert tool.description == "Greet someone."
+    assert tool.to_openai()["function"]["name"] == "greet"
+
+
+def test_resolve_base_tool_capabilities():
+    class Multi(BaseTool):
+        name = "multi"
+
+        @capability
+        def alpha(self, x: str) -> str:
+            """Alpha."""
+            return f"a{x}"
+
+        @capability
+        def beta(self, y: int) -> str:
+            """Beta."""
+            return f"b{y}"
+
+    tools = {t.name: t for t in resolve_tools([Multi()])}
+    assert set(tools) == {"alpha", "beta"}
+
+
+def test_resolve_registry_name():
+    (tool,) = resolve_tools(["current_datetime"])
+    assert tool.name == "current_datetime"
+    assert tool.context_param == "wrapper"
+
+
+def test_resolve_rejects_unknown_type():
+    with pytest.raises(TypeError, match="Unsupported tool type"):
+        resolve_tools([object()])
+
+
+@pytest.mark.asyncio
+async def test_tool_call_stringifies_non_str():
+    tool = Tool.from_function(lambda: {"a": 1}, name="t")
+    assert await tool.call({}) == '{"a": 1}'
+
+
+# --------------------------------------------------------------- the loop
+
+
+def weather(city: str) -> str:
+    """Weather.
+
+    Args:
+        city: city.
+    """
+    return f"{city}: sunny"
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_text_without_tools():
+    loop = AgentLoop(model=FakeModel(text("hello")), instructions="sys")
+    result = await loop.arun("hi")
+
+    assert result.final_output == "hello"
+    assert result.status == "completed"
+    assert result.usage.total_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_executes_tool_then_answers():
+    model = FakeModel(calls(("weather", '{"city": "Oslo"}')), text("It is sunny."))
+    loop = AgentLoop(model=model, tools=[weather])
+    result = await loop.arun("weather in Oslo?")
+
+    assert result.final_output == "It is sunny."
+    tool_results = [e for e in result.events if e.type == "tool_result"]
+    assert [e.result for e in tool_results] == ["Oslo: sunny"]
+
+    # the tool result must be fed back as a `tool` message keyed by call id
+    second_request = model.calls[1]["messages"]
+    assert second_request[-1]["role"] == "tool"
+    assert second_request[-1]["tool_call_id"] == "c0"
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_parallel_tool_calls():
+    model = FakeModel(
+        calls(("weather", '{"city": "A"}'), ("weather", '{"city": "B"}')),
+        text("both done"),
+    )
+    loop = AgentLoop(model=model, tools=[weather])
+    result = await loop.arun("two cities")
+
+    results = [e.result for e in result.events if e.type == "tool_result"]
+    assert results == ["A: sunny", "B: sunny"]
+
+
+@pytest.mark.asyncio
+async def test_loop_reports_unknown_tool_without_crashing():
+    model = FakeModel(calls(("nope", "{}")), text("recovered"))
+    loop = AgentLoop(model=model, tools=[weather])
+    result = await loop.arun("go")
+
+    (event,) = [e for e in result.events if e.type == "tool_result"]
+    assert event.error == "unknown tool"
+    assert "Available tools: weather" in event.result
+    assert result.final_output == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_loop_handles_malformed_arguments():
+    model = FakeModel(calls(("weather", "{not json")), text("recovered"))
+    loop = AgentLoop(model=model, tools=[weather])
+    result = await loop.arun("go")
+
+    (event,) = [e for e in result.events if e.type == "tool_result"]
+    assert "Invalid JSON" in event.error
+    assert result.final_output == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_failing_tool_is_disabled_after_budget():
+    """A tool that always raises must not consume every turn."""
+
+    executions = []
+
+    def flaky(x: str) -> str:
+        """Flaky.
+
+        Args:
+            x: anything.
+        """
+        executions.append(x)
+        raise RuntimeError("boom")
+
+    # the model keeps asking for the tool even after it stops being offered
+    model = FakeModel(
+        calls(("flaky", '{"x": "1"}')),
+        calls(("flaky", '{"x": "2"}')),
+        calls(("flaky", '{"x": "3"}')),
+        text("giving up"),
+    )
+    loop = AgentLoop(model=model, tools=[flaky], max_turns=10, max_tool_failures=2)
+    result = await loop.arun("go")
+
+    assert executions == ["1", "2"], "the tool must stop being executed at its budget"
+    assert result.status == "completed"
+    assert result.final_output == "giving up"
+    # once disabled it is withdrawn from the schema list too
+    assert model.calls[-1]["tools"] is None
+    disabled_result = [e for e in result.events if e.error == "tool disabled"]
+    assert len(disabled_result) == 1
+
+
+@pytest.mark.asyncio
+async def test_max_turns_terminates():
+    model = FakeModel(*[calls(("weather", '{"city": "X"}')) for _ in range(5)])
+    loop = AgentLoop(model=model, tools=[weather], max_turns=3)
+    result = await loop.arun("loop forever")
+
+    assert result.status == "max_turns"
+    assert "max_turns (3)" in result.error
+
+
+@pytest.mark.asyncio
+async def test_tool_exception_is_surfaced_not_raised():
+    def bad(x: str) -> str:
+        """Bad.
+
+        Args:
+            x: anything.
+        """
+        raise ValueError("nope")
+
+    model = FakeModel(calls(("bad", '{"x": "1"}')), text("ok"))
+    loop = AgentLoop(model=model, tools=[bad])
+    result = await loop.arun("go")
+
+    (event,) = [e for e in result.events if e.type == "tool_result" and e.error]
+    assert event.error == "ValueError: nope"
+
+
+@pytest.mark.asyncio
+async def test_context_is_passed_to_context_param():
+    seen = {}
+
+    def needs_ctx(wrapper: "RunContextWrapper[object]", q: str) -> str:  # noqa: F821
+        """Doc.
+
+        Args:
+            q: query.
+        """
+        seen["context"] = wrapper.context
+        return "ok"
+
+    sentinel = object()
+    model = FakeModel(calls(("needs_ctx", '{"q": "x"}')), text("done"))
+    loop = AgentLoop(model=model, tools=[needs_ctx], context=sentinel)
+    await loop.arun("go")
+
+    assert seen["context"] is sentinel
+
+
+@pytest.mark.asyncio
+async def test_message_list_input_is_passed_through():
+    model = FakeModel(text("ok"))
+    loop = AgentLoop(model=model)
+    await loop.arun(
+        [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+    )
+
+    assert [m["content"] for m in model.calls[0]["messages"]] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_astream_emits_expected_event_sequence():
+    model = FakeModel(calls(("weather", '{"city": "Rome"}')), text("sunny"))
+    loop = AgentLoop(model=model, tools=[weather])
+
+    types = [e.type async for e in loop.astream("go")]
+    assert types == [
+        "run_start",
+        "tool_call",
+        "tool_result",
+        "message",
+        "run_end",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_astream_text_deltas():
+    loop = AgentLoop(model=FakeModel(text("one two three")))
+    deltas = [
+        e.text
+        async for e in loop.astream("go", stream_text=True)
+        if e.type == "text_delta"
+    ]
+    assert "".join(deltas).strip() == "one two three"
+
+
+@pytest.mark.asyncio
+async def test_with_model_shares_tools():
+    loop = AgentLoop(model=FakeModel(text("a")), tools=[weather])
+    clone = loop.with_model(FakeModel(text("b")))
+
+    assert clone.tools is loop.tools
+    assert (await clone.arun("go")).final_output == "b"
+
+
+def test_run_rejects_being_called_inside_event_loop():
+    import asyncio
+
+    async def main():
+        with pytest.raises(RuntimeError, match="running event loop"):
+            AgentLoop(model=FakeModel(text("x"))).run("go")
+
+    asyncio.run(main())
+
+
+# --------------------------------------------------- Agentor integration
+
+
+def native(model, **kwargs):
+    from agentor import Agentor
+
+    return Agentor(name="T", model=model, engine="native", api_key="test", **kwargs)
+
+
+def test_agentor_defaults_to_the_agents_engine():
+    from agentor import Agentor
+
+    agent = Agentor(name="T", model="gpt-4o-mini", api_key="test")
+    assert agent.engine == "agents"
+    assert agent.agent is not None
+
+
+def test_agentor_native_run():
+    result = native(FakeModel(text("hi there")), tools=[weather]).run("go")
+    assert result.final_output == "hi there"
+
+
+def test_agentor_native_exposes_tool_metadata_for_a2a():
+    agent = native(FakeModel(text("x")), tools=[weather])
+    # serve() builds A2A skills from name/description on each tool
+    assert [(t.name, t.description) for t in agent.tools] == [("weather", "Weather.")]
+
+
+@pytest.mark.asyncio
+async def test_agentor_native_stream_chat_matches_wire_format():
+    agent = native(
+        FakeModel(calls(("weather", '{"city": "Rome"}')), text("sunny")),
+        tools=[weather],
+    )
+    outputs = [o async for o in agent.stream_chat("go", serialize=False)]
+
+    assert [o.tool_action.type for o in outputs if o.tool_action] == [
+        "tool_called",
+        "tool_output",
+    ]
+    assert outputs[-1].message == "sunny"
+    assert all(o.type == "run_item_stream_event" for o in outputs)
+
+
+@pytest.mark.asyncio
+async def test_agentor_native_chat_non_streaming():
+    agent = native(FakeModel(text("answer")))
+    result = await agent.chat("go")
+    assert result.final_output == "answer"
+
+
+def test_agentor_native_rejects_mcp_servers_loudly():
+    from agentor.mcp import MCPServerStreamableHttp
+
+    server = MCPServerStreamableHttp(name="m", params={"url": "http://example"})
+    with pytest.raises(NotImplementedError, match="MCP servers"):
+        native(FakeModel(text("x")), tools=[server])
+
+
+@pytest.mark.asyncio
+async def test_agentor_native_falls_back_on_rate_limit():
+    import httpx
+    import openai
+
+    response = httpx.Response(
+        429, request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    )
+
+    class Failing:
+        model = "primary"
+
+        async def complete(self, messages, tools=None):
+            raise openai.RateLimitError("rate limited", response=response, body=None)
+
+    agent = native(Failing())
+    agent._loop.with_model = lambda *a, **k: AgentLoop(
+        model=FakeModel(text("from fallback"))
+    )
+
+    result = await agent.arun("go", fallback_models=["backup"])
+    assert result.final_output == "from fallback"


### PR DESCRIPTION
Phase 1 of the v0.1.0 migration. **Stacked on #137** — review that first; this PR's base retargets to `agentor-v0.1.0` automatically once #137 merges.

Adds `agentor/engine/` (917 LOC): an agent loop we own end to end, behind `engine="native"`. Default stays `"agents"`, so nothing changes for existing users.

**Nothing under `agentor/engine/` imports openai-agents.** That's the point — Phase 5 becomes a deletion, not a rewrite.

| file | LOC | |
|---|---|---|
| `events.py` | 87 | `Event`/`RunResult`/`Usage` — one description of a run |
| `tools.py` | 260 | schema generation, docstring parsing, one `Tool` type |
| `models.py` | 257 | `Model` protocol, `ChatCompletionsModel`, `LiteLLMModel` |
| `loop.py` | 279 | the loop: sync/async/stream, budgets, model swap |

## Two bugs worth calling out

**The spike bug is fixed.** A tool that raises used to burn all 10 turns (10 wasted API calls). A failure budget disables it after 2.

**Writing the test for that fix found a second bug.** My first fix only withdrew the failing tool's *schema* — but a model can still emit a call for a tool it wasn't offered, so the broken tool kept executing anyway. The budget is now enforced at execution, not just advertisement. The test asserts on actual invocations rather than error events, which is the property that matters.

## No tool-calling regression

The current engine extracts param descriptions from Google-style docstrings via griffe. Every tool in this repo documents its args that way. Generating bare type schemas would have quietly degraded tool-calling accuracy with no test failure to catch it — so `tools.py` parses them too, and a parity check asserts the output matches openai-agents field for field.

Legacy registry tools take a `RunContextWrapper` first argument. It's detected **by type name rather than import**, excluded from the schema, and injected at call time — so those tools work unchanged while the engine stays free of openai-agents.

## Compatibility

`stream_chat` projects engine events onto the existing `AgentOutput` wire format, so `serve()`, `/chat` and the A2A handler are untouched. Verified the emitted JSON keys are identical across both engines.

## Measured

| | agents | native |
|---|---|---|
| import | 1.124s | **0.047s** |
| agent construction (5 tools) | 1.17 ms | 4.39 ms |

Construction is ~3 ms *slower*: schemas are built with pydantic (`create_model` + `model_json_schema` is 0.176 ms of the 0.211 ms per tool). **Deliberately not optimised** — it's noise against a 500 ms+ model call, and a cache would add invalidation logic for no user-visible gain.

## Verification

- **30 new unit tests** against a scripted fake model — no network. Cover parallel tool calls, streamed tool-call reassembly from fragmented deltas, failure budget, max_turns, unknown tools, malformed JSON args, context injection, model swap.
- **22/22 live checks** against the real API: schema parity, parallel calls, streaming, error paths.
- `186 passed, 2 skipped` overall. Ruff clean on all new files.

## Known gaps

`engine="native"` does not yet support MCP servers, `output_type`, or `WebSearchTool`. MCP **raises `NotImplementedError`** rather than silently dropping the server — passing a tool that gets ignored is the worst failure mode here.

## Caveat on multi-provider

I verified `base_url` routing works, but against OpenAI's own endpoint — I don't have third-party provider keys in this environment. The claim that Anthropic/Gemini/Groq/etc. work via their OpenAI-compatible endpoints is **untested here**. Worth a real check before flipping the default in Phase 5. `provider/model` strings still route to litellm exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an opt-in native agent engine while retaining the existing agents engine as the default.
- Introduces normalized run events, native tool resolution and schema generation, chat-completions and LiteLLM model adapters, and synchronous, asynchronous, and streaming loop entry points.
- Routes Agentor operations through the native loop when `engine="native"`, including streaming projection and model fallback support.
- Adds scripted-model tests for tool execution, streaming reassembly, failure budgets, turn limits, context injection, and fallback behavior.
- Updates the migration plan with the implemented Phase 1 architecture and measurements.

<h3>Confidence Score: 2/5</h3>

The PR is not yet safe to merge because native runs can exceed tool and turn budgets, lose legacy tool context, and silently ignore requested structured output.

Parallel failure accounting permits excess tool executions, the FunctionTool adapter replaces the real run context with None, native arun ignores its public max_turns override, and output_type is accepted without enforcement or rejection.

**Files Needing Attention:** src/agentor/engine/loop.py, src/agentor/engine/tools.py, src/agentor/core/agent.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/core/agent.py | Adds native-engine routing, but silently ignores output_type and drops per-call max_turns on native asynchronous runs. |
| src/agentor/engine/loop.py | Implements the native event-driven loop, but parallel same-tool failures can exceed the configured execution budget. |
| src/agentor/engine/tools.py | Adds schema generation and legacy tool adaptation, but the FunctionTool adapter discards the configured run context. |
| src/agentor/engine/models.py | Adds model protocols and OpenAI-compatible and LiteLLM adapters; no independent blocking defect was established. |
| src/agentor/engine/events.py | Defines normalized event, usage, and run-result data structures without an identified defect. |
| tests/test_engine.py | Provides broad native-engine coverage but omits parallel failing calls, direct context-dependent FunctionTool adaptation, output_type rejection, and Agentor-level max_turns overrides. |
| docs/dev/MIGRATION_PLAN.md | Documents the native engine architecture, verification, and known compatibility gaps. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agentor API] --> B{engine}
    B -->|agents| C[openai-agents Runner]
    B -->|native| D[AgentLoop]
    D --> E[Model adapter]
    E --> F{Tool calls?}
    F -->|No| G[RunResult and stream projection]
    F -->|Yes| H[Resolve and execute tools]
    H --> I[Append tool results]
    I --> E
```

<sub>Reviews (1): Last reviewed commit: ["feat(engine): native agent loop behind e..."](https://github.com/celestoai/agentor/commit/92d0b091f04c9336a23f359384796e7c7035e53f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48296865)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->