### PR TITLE
feat(engine): native tracing from the event stream

### DIFF
--- a/docs/dev/MIGRATION_PLAN.md
+++ b/docs/dev/MIGRATION_PLAN.md
@@ -231,10 +231,38 @@ Collapse `FunctionTool` / `BaseTool` / `ToolRegistry` onto the single `Tool` typ
 `RunContextWrapper` from user-facing signatures — context becomes a plain argument.
 Keep `@tool`, `@capability`, and `BaseTool.from_function` working.
 
-### Phase 3 — Native tracing (2 days)
+### Phase 3 — Native tracing ✅ *shipped*
 
-Celesto exporter consumes `Event` directly. Deletes the `hasattr` introspection in `tracer.py`
-and — for the first time — covers every code path, including `LLM` and durable runs.
+Reordered ahead of Phase 2, for two reasons: Phase 2 mostly deletes the `FunctionTool` bridge,
+which cannot go until the native engine is the default (Phase 5); and Phase 1 opened a hole that
+needed closing.
+
+**The hole:** `engine="native"` wired tracing to the openai-agents trace processor, which cannot
+observe a run that never enters openai-agents. Native runs produced **no traces, with no warning**.
+
+`agentor/engine/tracing.py` (160 LOC) projects the event stream onto Celesto trace payloads:
+one trace per run, a `generation` span per model call, a `function` span per tool call, all
+parented to an `agent` span. No `hasattr` chains — the events already describe the run, so the
+tracer reads nothing from the engine's internals. That is the structural difference from
+`tracer.py`, whose `_convert_span` is ~75 lines of defensive introspection into another vendor's
+objects.
+
+Verified on a live run:
+
+```
+TRACE trace_17d6486d…  Weather Agent
+  SPAN generation  gpt-4o-mini    67 tokens
+  SPAN function    get_weather
+  SPAN generation  gpt-4o-mini    94 tokens
+  SPAN agent       Weather Agent  161 tokens
+```
+
+- Tracing failures cannot break a run: collector and export errors are caught and logged, proven
+  by a test with a tracer that raises from both.
+- Export runs on a worker thread, so a slow ingest endpoint does not block the event loop.
+- Known limitation: a caller that abandons `astream` early never reaches export. `arun` always drains.
+
+12 tracing tests; 198 passing overall.
 
 ### Phase 4 — Fold in durability (2–3 days)
 

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -292,7 +292,7 @@ class Agentor(AgentorBase):
         self.agent = None
         self.mcp_servers = []
         self.enable_tracing = enable_tracing
-        self._setup_tracing(enable_tracing)
+        tracer = self._native_tracer(enable_tracing)
 
         for tool in tools or []:
             if isinstance(tool, MCPServerStreamableHttp):
@@ -320,27 +320,38 @@ class Agentor(AgentorBase):
             context=CelestoConfig(),
             max_turns=max_turns,
             api_key=api_key,
+            tracer=tracer,
             **params,
         )
 
-    def _setup_tracing(self, enable_tracing: bool) -> None:
-        """Tracing setup shared with AgentorBase, without the agents-only bits."""
+    def _native_tracer(self, enable_tracing: bool):
+        """Build a tracer for the native engine.
+
+        The openai-agents trace processor cannot see native runs at all, so
+        this uses the engine's own event stream instead.
+        """
         if not enable_tracing and (
             celesto_config.api_key is None or celesto_config.disable_auto_tracing
         ):
-            return
-        if enable_tracing and not celesto_config.api_key:
-            raise ValueError(
-                "Celesto API key is required to enable tracing. "
-                "Find it at https://celesto.ai/dashboard and set CELESTO_API_KEY."
-            )
+            return None
+        if not celesto_config.api_key:
+            if enable_tracing:
+                raise ValueError(
+                    "Celesto API key is required to enable tracing. "
+                    "Find it at https://celesto.ai/dashboard and set CELESTO_API_KEY."
+                )
+            return None
+
+        from agentor.engine.tracing import CelestoTracer
+
         try:
-            setup_celesto_tracing(
+            return CelestoTracer(
                 endpoint=f"{celesto_config.base_url}/traces/ingest",
                 token=celesto_config.api_key.get_secret_value(),
             )
         except Exception as e:
             logger.warning(f"Failed to setup Celesto tracing: {e}")
+            return None
 
     def _inject_skills(self, skills: List[str]) -> str:
         """Inject skills into the agent system prompt."""

--- a/src/agentor/engine/events.py
+++ b/src/agentor/engine/events.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Literal, Optional
 EventType = Literal[
     "run_start",
     "text_delta",
+    "generation",
     "message",
     "tool_call",
     "tool_result",
@@ -59,6 +60,14 @@ class Event:
     status: Optional[RunStatus] = None
     agent: Optional[str] = None
     model: Optional[str] = None
+    #: messages sent to the model; set on `generation` so a trace can show the
+    #: exact request, which is the part that is hardest to reconstruct later
+    messages: Optional[List[Dict[str, Any]]] = None
+    #: tool calls the model asked for, on `generation`
+    calls: Optional[List[Dict[str, Any]]] = None
+    #: epoch seconds bounding the work this event describes; spans need both
+    started_at: Optional[float] = None
+    ended_at: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v is not None}

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from agentor.engine.events import Event, RunResult, Usage
@@ -35,6 +36,7 @@ class AgentLoop:
         max_tool_failures: int = 2,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
+        tracer: Any = None,
         **model_params: Any,
     ):
         self.name = name
@@ -42,6 +44,7 @@ class AgentLoop:
         self.context = context
         self.max_turns = max_turns
         self.max_tool_failures = max_tool_failures
+        self.tracer = tracer
         self.model: Model = resolve_model(
             model, api_key=api_key, base_url=base_url, **model_params
         )
@@ -131,6 +134,7 @@ class AgentLoop:
                 result=f"Error: unknown tool {call.name!r}. Available tools: {known}.",
             )
 
+        started = time.time()
         try:
             result = await tool.call(args, context=self.context)
             return Event(
@@ -139,6 +143,8 @@ class AgentLoop:
                 args=args,
                 call_id=call.id,
                 result=result,
+                started_at=started,
+                ended_at=time.time(),
             )
         except Exception as exc:
             # Surfaced to the model rather than raised: a failing tool is
@@ -151,6 +157,8 @@ class AgentLoop:
                 call_id=call.id,
                 error=f"{type(exc).__name__}: {exc}",
                 result=f"Error: {type(exc).__name__}: {exc}",
+                started_at=started,
+                ended_at=time.time(),
             )
 
     # ------------------------------------------------------------ the loop
@@ -158,19 +166,53 @@ class AgentLoop:
     async def astream(
         self, input: MessageInput, stream_text: bool = False
     ) -> AsyncIterator[Event]:
+        """Run the agent, emitting every event, and trace it if configured.
+
+        Note that a consumer which abandons this generator early stops the
+        trace from being exported; `arun` always drains it.
+        """
+        if self.tracer is None:
+            async for event in self._astream(input, stream_text):
+                yield event
+            return
+
+        collector = self.tracer.collector(self.name)
+        async for event in self._astream(input, stream_text):
+            try:
+                collector.handle(event)
+            except Exception as e:  # tracing must never break a run
+                logger.warning("Trace collection failed: %s", e)
+            yield event
+
+        try:
+            await asyncio.to_thread(self.tracer.export, collector)
+        except Exception as e:
+            logger.warning("Trace export failed: %s", e)
+
+    async def _astream(
+        self, input: MessageInput, stream_text: bool = False
+    ) -> AsyncIterator[Event]:
         messages = self._initial_messages(input)
         failures: Dict[str, int] = {}
         disabled: set[str] = set()
         total = Usage()
 
+        model_name = getattr(self.model, "model", None)
+        run_started = time.time()
+
         yield Event(
             type="run_start",
             agent=self.name,
-            model=getattr(self.model, "model", None),
+            model=model_name,
+            started_at=run_started,
         )
 
         for turn in range(1, self.max_turns + 1):
             schemas = self._schemas(disabled)
+            # snapshot before the call: `messages` is appended to below, and a
+            # trace needs the request as it was actually sent
+            request_messages = [dict(m) for m in messages]
+            call_started = time.time()
 
             if stream_text:
                 response = None
@@ -185,7 +227,20 @@ class AgentLoop:
                 response = await self.model.complete(messages, schemas)
 
             total = total + response.usage
-            messages.append(self._assistant_message(response))
+            assistant = self._assistant_message(response)
+            messages.append(assistant)
+
+            yield Event(
+                type="generation",
+                turn=turn,
+                model=model_name,
+                messages=request_messages,
+                text=response.content,
+                calls=assistant.get("tool_calls"),
+                usage=response.usage,
+                started_at=call_started,
+                ended_at=time.time(),
+            )
 
             if not response.tool_calls:
                 text = response.content or ""
@@ -196,6 +251,8 @@ class AgentLoop:
                     status="completed",
                     usage=total,
                     turn=turn,
+                    started_at=run_started,
+                    ended_at=time.time(),
                 )
                 return
 
@@ -256,6 +313,8 @@ class AgentLoop:
             status="max_turns",
             error=f"Reached max_turns ({self.max_turns}) without a final answer.",
             usage=total,
+            started_at=run_started,
+            ended_at=time.time(),
         )
 
     async def arun(self, input: MessageInput) -> RunResult:

--- a/src/agentor/engine/tracing.py
+++ b/src/agentor/engine/tracing.py
@@ -1,0 +1,166 @@
+"""Celesto tracing for the native engine.
+
+The event stream already describes a run completely, so a trace is a direct
+projection of it rather than a second representation. Nothing here reads the
+engine's internals, which is what made the openai-agents exporter fragile.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from agentor.engine.events import Event
+
+logger = logging.getLogger(__name__)
+
+
+def _iso(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+class TraceCollector:
+    """Builds Celesto trace/span payloads from engine events.
+
+    One trace per run; a `generation` span per model call and a `function`
+    span per tool call, both parented to the run's agent span.
+    """
+
+    def __init__(
+        self,
+        workflow_name: str,
+        group_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        self.trace_id = f"trace_{uuid.uuid4().hex}"
+        self.workflow_name = workflow_name
+        self.group_id = group_id
+        self.metadata = metadata
+        self.agent_span_id = f"span_{uuid.uuid4().hex}"
+        self.items: List[Dict[str, Any]] = []
+
+    def _span(
+        self, span_data: Dict[str, Any], event: Event, parent: Optional[str] = None
+    ) -> Dict[str, Any]:
+        return {
+            "object": "trace.span",
+            "span_id": f"span_{uuid.uuid4().hex}",
+            "trace_id": self.trace_id,
+            "parent_id": parent or self.agent_span_id,
+            "started_at": _iso(event.started_at),
+            "ended_at": _iso(event.ended_at),
+            "span_data": span_data,
+        }
+
+    def handle(self, event: Event) -> None:
+        if event.type == "run_start":
+            self.items.append(
+                {
+                    "object": "trace",
+                    "id": self.trace_id,
+                    "workflow_name": self.workflow_name,
+                    "group_id": self.group_id,
+                    "metadata": self.metadata,
+                }
+            )
+            self._agent_started_at = event.started_at
+            self._agent_name = event.agent
+            self._agent_model = event.model
+
+        elif event.type == "generation":
+            self.items.append(
+                self._span(
+                    {
+                        "type": "generation",
+                        "model": event.model,
+                        "input": event.messages,
+                        "output": event.text,
+                        "tool_calls": event.calls,
+                        "usage": {
+                            "input_tokens": event.usage.input_tokens,
+                            "output_tokens": event.usage.output_tokens,
+                            "total_tokens": event.usage.total_tokens,
+                        }
+                        if event.usage
+                        else None,
+                    },
+                    event,
+                )
+            )
+
+        elif event.type == "tool_result":
+            span = self._span(
+                {
+                    "type": "function",
+                    "name": event.name,
+                    "input": event.args,
+                    "output": event.result,
+                },
+                event,
+            )
+            if event.error:
+                span["error"] = {"message": event.error}
+            self.items.append(span)
+
+        elif event.type == "run_end":
+            span = {
+                "object": "trace.span",
+                "span_id": self.agent_span_id,
+                "trace_id": self.trace_id,
+                "parent_id": None,
+                "started_at": _iso(event.started_at),
+                "ended_at": _iso(event.ended_at),
+                "span_data": {
+                    "type": "agent",
+                    "name": getattr(self, "_agent_name", self.workflow_name),
+                    "model": getattr(self, "_agent_model", None),
+                    "output": event.text,
+                    "status": event.status,
+                    "usage": {
+                        "input_tokens": event.usage.input_tokens,
+                        "output_tokens": event.usage.output_tokens,
+                        "total_tokens": event.usage.total_tokens,
+                    }
+                    if event.usage
+                    else None,
+                },
+            }
+            if event.error:
+                span["error"] = {"message": event.error}
+            self.items.append(span)
+
+
+class CelestoTracer:
+    """Collects a run's events and ships them to the Celesto ingest API."""
+
+    def __init__(self, endpoint: str, token: str, timeout: float = 10.0):
+        self.endpoint = endpoint
+        self.token = token
+        self.timeout = timeout
+
+    def collector(self, workflow_name: str, **kwargs: Any) -> TraceCollector:
+        return TraceCollector(workflow_name, **kwargs)
+
+    def export(self, collector: TraceCollector) -> None:
+        if not collector.items:
+            return
+        import httpx
+
+        try:
+            response = httpx.post(
+                self.endpoint,
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Content-Type": "application/json",
+                },
+                json={"data": collector.items},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception as e:
+            # Tracing must never take down the agent run.
+            logger.warning("Failed to export traces to Celesto: %s", e)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -333,11 +333,49 @@ async def test_astream_emits_expected_event_sequence():
     types = [e.type async for e in loop.astream("go")]
     assert types == [
         "run_start",
+        "generation",
         "tool_call",
         "tool_result",
+        "generation",
         "message",
         "run_end",
     ]
+
+
+@pytest.mark.asyncio
+async def test_generation_events_carry_span_data():
+    model = FakeModel(calls(("weather", '{"city": "Rome"}')), text("sunny"))
+    loop = AgentLoop(model=model, tools=[weather], instructions="sys")
+
+    events = [e async for e in loop.astream("go")]
+    generations = [e for e in events if e.type == "generation"]
+    assert len(generations) == 2
+
+    first, second = generations
+    # the request as actually sent, before the assistant reply was appended
+    assert [m["role"] for m in first.messages] == ["system", "user"]
+    assert first.calls[0]["function"]["name"] == "weather"
+    assert first.model == "fake-model"
+    assert first.ended_at >= first.started_at
+
+    # the second call must include the tool result
+    assert [m["role"] for m in second.messages] == [
+        "system",
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert second.text == "sunny"
+
+
+@pytest.mark.asyncio
+async def test_tool_result_events_are_timed():
+    model = FakeModel(calls(("weather", '{"city": "Rome"}')), text("ok"))
+    loop = AgentLoop(model=model, tools=[weather])
+
+    result = await loop.arun("go")
+    (event,) = [e for e in result.events if e.type == "tool_result"]
+    assert event.started_at is not None and event.ended_at >= event.started_at
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_tracing.py
+++ b/tests/test_engine_tracing.py
@@ -1,0 +1,200 @@
+"""Tests for native-engine tracing (agentor.engine.tracing)."""
+
+import pytest
+from tests.test_engine import FakeModel, calls, text, weather
+
+from agentor.engine import AgentLoop
+from agentor.engine.tracing import CelestoTracer, TraceCollector
+
+
+class RecordingTracer:
+    """Captures what would have been exported instead of sending it."""
+
+    def __init__(self):
+        self.exported = []
+
+    def collector(self, workflow_name, **kwargs):
+        return TraceCollector(workflow_name, **kwargs)
+
+    def export(self, collector):
+        self.exported.append(collector.items)
+
+
+@pytest.mark.asyncio
+async def test_run_produces_a_trace_and_spans():
+    tracer = RecordingTracer()
+    loop = AgentLoop(
+        name="Weather Agent",
+        model=FakeModel(calls(("weather", '{"city": "Rome"}')), text("sunny")),
+        tools=[weather],
+        tracer=tracer,
+    )
+    await loop.arun("go")
+
+    (items,) = tracer.exported
+    kinds = [
+        i["object"] if i["object"] == "trace" else i["span_data"]["type"] for i in items
+    ]
+    assert kinds == ["trace", "generation", "function", "generation", "agent"]
+
+    trace = items[0]
+    assert trace["workflow_name"] == "Weather Agent"
+    assert trace["id"].startswith("trace_")
+
+
+@pytest.mark.asyncio
+async def test_spans_share_one_trace_and_parent():
+    tracer = RecordingTracer()
+    loop = AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "A"}')), text("done")),
+        tools=[weather],
+        tracer=tracer,
+    )
+    await loop.arun("go")
+    (items,) = tracer.exported
+
+    trace_id = items[0]["id"]
+    spans = items[1:]
+    assert {s["trace_id"] for s in spans} == {trace_id}
+
+    agent_span = next(s for s in spans if s["span_data"]["type"] == "agent")
+    children = [s for s in spans if s["span_data"]["type"] != "agent"]
+    assert agent_span["parent_id"] is None
+    assert {s["parent_id"] for s in children} == {agent_span["span_id"]}
+
+
+@pytest.mark.asyncio
+async def test_generation_span_carries_request_and_usage():
+    tracer = RecordingTracer()
+    loop = AgentLoop(
+        model=FakeModel(text("hello")), tracer=tracer, instructions="be nice"
+    )
+    await loop.arun("hi")
+
+    (items,) = tracer.exported
+    generation = next(i for i in items[1:] if i["span_data"]["type"] == "generation")
+    data = generation["span_data"]
+
+    assert [m["role"] for m in data["input"]] == ["system", "user"]
+    assert data["output"] == "hello"
+    assert data["usage"]["total_tokens"] == 3
+    assert generation["started_at"] and generation["ended_at"]
+
+
+@pytest.mark.asyncio
+async def test_tool_failure_is_recorded_on_the_span():
+    def broken(x: str) -> str:
+        """Broken.
+
+        Args:
+            x: anything.
+        """
+        raise RuntimeError("boom")
+
+    tracer = RecordingTracer()
+    loop = AgentLoop(
+        model=FakeModel(calls(("broken", '{"x": "1"}')), text("gave up")),
+        tools=[broken],
+        tracer=tracer,
+    )
+    await loop.arun("go")
+
+    (items,) = tracer.exported
+    function_span = next(i for i in items[1:] if i["span_data"]["type"] == "function")
+    assert function_span["error"]["message"] == "RuntimeError: boom"
+    assert function_span["span_data"]["name"] == "broken"
+
+
+@pytest.mark.asyncio
+async def test_max_turns_is_recorded_as_a_failed_agent_span():
+    tracer = RecordingTracer()
+    loop = AgentLoop(
+        model=FakeModel(*[calls(("weather", '{"city": "X"}')) for _ in range(4)]),
+        tools=[weather],
+        max_turns=2,
+        tracer=tracer,
+    )
+    await loop.arun("go")
+
+    (items,) = tracer.exported
+    agent_span = next(i for i in items[1:] if i["span_data"]["type"] == "agent")
+    assert agent_span["span_data"]["status"] == "max_turns"
+    assert "max_turns" in agent_span["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_broken_tracer_cannot_break_a_run():
+    class Exploding:
+        def collector(self, *a, **k):
+            class C:
+                items = [{"x": 1}]
+
+                def handle(self, event):
+                    raise RuntimeError("collector is broken")
+
+            return C()
+
+        def export(self, collector):
+            raise RuntimeError("export is broken")
+
+    loop = AgentLoop(model=FakeModel(text("fine")), tracer=Exploding())
+    result = await loop.arun("go")
+
+    assert result.final_output == "fine"
+    assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_no_tracer_means_no_overhead_path():
+    loop = AgentLoop(model=FakeModel(text("fine")))
+    assert loop.tracer is None
+    assert (await loop.arun("go")).final_output == "fine"
+
+
+def test_export_swallows_network_errors(monkeypatch):
+    tracer = CelestoTracer(
+        endpoint="http://127.0.0.1:1/ingest", token="t", timeout=0.01
+    )
+    collector = TraceCollector("wf")
+    collector.items.append({"object": "trace", "id": "trace_1"})
+
+    # unreachable endpoint must not raise into the caller
+    tracer.export(collector)
+
+
+def test_export_skips_when_there_is_nothing_to_send(monkeypatch):
+    import httpx
+
+    posts = []
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: posts.append(a))
+
+    tracer = CelestoTracer(endpoint="http://example/ingest", token="t")
+    tracer.export(TraceCollector("wf"))
+
+    assert posts == [], "an empty collector must not hit the network"
+
+
+def test_agentor_native_wires_a_tracer_when_configured(monkeypatch):
+    from agentor import config as config_module
+
+    monkeypatch.setattr(
+        config_module.celesto_config, "api_key", _Secret("cel_test"), raising=False
+    )
+    monkeypatch.setattr(
+        config_module.celesto_config, "disable_auto_tracing", False, raising=False
+    )
+
+    from agentor import Agentor
+
+    agent = Agentor(
+        name="T", model=FakeModel(text("x")), engine="native", api_key="test"
+    )
+    assert isinstance(agent._loop.tracer, CelestoTracer)
+
+
+class _Secret:
+    def __init__(self, value):
+        self.value = value
+
+    def get_secret_value(self):
+        return self.value

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,8 +1,10 @@
+from typing import Annotated
+
+import pytest
+from fastapi import Depends
+
 from agentor import CelestoMCPHub
 from agentor.mcp import MCPAPIRouter
-from fastapi import Depends
-import pytest
-from typing import Annotated
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_context.py
+++ b/tests/test_mcp_context.py
@@ -1,8 +1,10 @@
-from agentor.mcp import MCPAPIRouter, Context, get_context
+from typing import Annotated
+
+import pytest
 from fastapi import Depends
 from fastapi.testclient import TestClient
-import pytest
-from typing import Annotated
+
+from agentor.mcp import Context, MCPAPIRouter, get_context
 
 
 @pytest.mark.asyncio

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,10 +1,8 @@
 """Tests for the Celesto tracing module."""
 
-import os
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import httpx
-import pytest
 from agents.tracing import Span, Trace
 
 from agentor.tracer import (


### PR DESCRIPTION
Phase 3 of the v0.1.0 migration. **Stacked on #138** (which is stacked on #137).

## Why this jumped the queue

Phase 2 (tool unification) is mostly *deleting* the `FunctionTool` bridge — which can't happen until the native engine is the default in Phase 5. So it's largely blocked.

Phase 3 isn't, **and it closes a hole #138 opened**: `engine="native"` wired tracing to the openai-agents trace processor, which cannot observe a run that never enters openai-agents. Native runs produced **no traces, and said nothing about it**. Silent observability loss is the worst kind, and observability is the product.

## What this does

`agentor/engine/tracing.py` (160 LOC) projects the event stream onto Celesto trace payloads: one trace per run, a `generation` span per model call, a `function` span per tool call, all parented to an `agent` span.

The structural point: **it reads nothing from the engine's internals.** The events already describe the run completely. Compare [tracer.py:110-183](src/agentor/tracer.py:110) — `_convert_span` is ~75 lines of defensive `hasattr` chains reverse-engineering another vendor's span objects. This is the difference owning the loop was supposed to buy, made concrete.

To make spans possible the engine now emits a `generation` event per model call carrying the request **as actually sent** (snapshotted before the assistant reply is appended), the response, tool calls and usage. `tool_result` and `run_end` carry `started_at`/`ended_at`.

## Verified on a live run

```
TRACE trace_17d6486d…  Weather Agent
  SPAN generation  gpt-4o-mini    67 tokens
  SPAN function    get_weather
  SPAN generation  gpt-4o-mini    94 tokens
  SPAN agent       Weather Agent  161 tokens
```

Hierarchy, token accounting (67+94=161 rolled up), and timing on every span.

## Tracing can't break a run

Collector and export errors are caught and logged — proven by a test using a tracer that raises from *both* paths, asserting the run still returns its answer. Export goes through `asyncio.to_thread` so a slow ingest endpoint doesn't block the event loop.

## Known limitation

A caller that abandons `astream()` early never reaches export. `arun()` always drains it. Documented in the docstring rather than papered over.

## Verification

- 12 new tracing tests, `198 passed, 2 skipped` overall.
- Ruff clean, formatted.
- One test I wrote was asserting nothing real (`assert calls_made == []` against a list nothing appended to) — rewritten to monkeypatch `httpx.post` and actually prove an empty collector skips the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds native-engine tracing derived from the event stream.
- Emits generation events containing model requests, responses, tool calls, usage, and timing.
- Projects run, generation, and tool-result events into Celesto trace and span payloads.
- Wires native Agentor instances to the new tracer and exports traces off the event loop.
- Adds tracing, event-shape, timing, and failure-isolation tests and updates the migration plan.

<h3>Confidence Score: 3/5</h3>

The missing timestamps on reachable tool-validation spans should be fixed before merging; collector initialization should also be covered by tracing failure isolation.

Unknown, disabled, and malformed tool requests return before timing starts but are still exported as function spans, producing incomplete trace data, while a collector initialization exception can still escape the tracing safeguards.

**Files Needing Attention:** src/agentor/engine/loop.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/engine/loop.py | Adds tracing integration and event timing, but early tool-result paths omit timestamps and collector initialization is not failure-isolated. |
| src/agentor/engine/tracing.py | Introduces event-to-trace projection and non-blocking export; it faithfully exposes missing timestamps received from tool-result events. |
| src/agentor/engine/events.py | Extends the event contract with generation payloads and timing fields. |
| src/agentor/core/agent.py | Replaces openai-agents tracing setup on the native path with CelestoTracer construction and injection. |
| tests/test_engine_tracing.py | Covers normal tracing and handle/export isolation but omits early tool-validation timing and collector-construction failure cases. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[AgentLoop._astream] -->|run_start| C[TraceCollector]
    A -->|generation| C
    A -->|tool_result| C
    A -->|run_end| C
    C --> T[Trace payload]
    T -->|asyncio.to_thread| E[Celesto ingest API]
```

<sub>Reviews (1): Last reviewed commit: ["feat(engine): native tracing from the ev..."](https://github.com/celestoai/agentor/commit/0f35ee4d97d2538789f83baaf248499b0a7c5673) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48297764)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->