### PR TITLE
feat(engine): MCP client and structured output for the native engine

### DIFF
--- a/docs/dev/MIGRATION_PLAN.md
+++ b/docs/dev/MIGRATION_PLAN.md
@@ -296,11 +296,45 @@ knowing only the run id, reads it from disk and finishes the job.
 **Deferred:** HITL interrupt/approval. The store makes it straightforward, but nothing in the
 codebase needs it yet and the brief says not to ship features nobody uses.
 
-### Phase 5 — Drop openai-agents (1 day)
+### Phase 5a — Close the native engine's gaps ✅ *shipped*
 
-Swap `agents.mcp.MCPServerStreamableHttp` for the official `mcp` client — **verified working**
-via `mcp.client.streamable_http.streamablehttp_client` + `ClientSession`, already a direct dep.
-Flip the default engine, remove the dependency, delete `output_text_formatter.py`'s SDK half.
+Split out from Phase 5. Flipping the default engine changes behaviour for every user, so it
+should not ride along with the work that makes the flip possible — and not on top of an
+unreviewed stack.
+
+**MCP** (`agentor/engine/mcp.py`, 150 LOC) on the official `mcp` package. Remote tools become
+ordinary `Tool` objects, so the loop, the failure budget and tracing all apply to them unchanged.
+Connections are held for the duration of a run and closed after — including when the run raises.
+An `Agentor(tools=[MCPServerStreamableHttp(...)])` call is adapted automatically, so the same
+code works on either engine.
+
+Verified against a real server (agentor's own LiteMCP, 9/9): discovery, remote calls, local and
+remote tools in one run, cleanup, and MCP calls appearing as spans in traces.
+
+*An MCP session is bound to the event loop that opened it.* Closing it from another loop produced
+anyio's `Attempted to exit cancel scope in a different task`, which names the mechanism rather
+than the mistake — `close()` now raises a message that says what to do instead. Worth noting the
+error came from **my own verification script**, not the engine; the production path was clean.
+
+**Structured output.** `output_type=SomeModel` sends a strict `json_schema` response format and
+parses the result. Parsing happens at the boundary so events stay plain text and the persisted
+log stays JSON-serialisable — durability and structured output do not interfere.
+
+`response_format` is only passed when set, so a `Model` adapter written before this still works.
+
+233 tests passing.
+
+### Phase 5b — Flip the default and remove openai-agents (not started)
+
+Remaining before the flip:
+
+- `WebSearchTool` and other OpenAI hosted tools need a Responses API adapter, or to be documented
+  as `engine="agents"` only.
+- **Verify a non-OpenAI provider end to end.** `base_url` routing is verified only against
+  OpenAI's own endpoint; no third-party keys were available. This is the single biggest untested
+  assumption in the plan.
+- Then: flip the default, drop the dependency, delete the openai-agents half of
+  `output_text_formatter.py` and `tracer.py`.
 
 **Total: ~2.5 weeks.**
 

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -590,7 +590,9 @@ class Agentor(AgentorBase):
         Run a task with optional fallback to alternative models on rate limit errors.
         """
         if self.engine == "native":
-            return await self._run_native_with_fallback(task, fallback_models)
+            return await self._run_native_with_fallback(
+                task, fallback_models, max_turns
+            )
 
         retryable = _retryable_errors()
         try:
@@ -639,7 +641,10 @@ class Agentor(AgentorBase):
             raise
 
     async def _run_native_with_fallback(
-        self, task: str, fallback_models: Optional[List[str]] = None
+        self,
+        task: str,
+        fallback_models: Optional[List[str]] = None,
+        max_turns: Optional[int] = None,
     ):
         """Native-engine equivalent of _run_with_fallback.
 
@@ -648,7 +653,7 @@ class Agentor(AgentorBase):
         """
         retryable = _retryable_errors()
         try:
-            return await self._loop.arun(task)
+            return await self._loop.arun(task, max_turns=max_turns)
         except retryable as e:
             if not fallback_models:
                 raise
@@ -660,7 +665,7 @@ class Agentor(AgentorBase):
                 try:
                     return await self._loop.with_model(
                         fallback_model, api_key=self.api_key
-                    ).arun(task)
+                    ).arun(task, max_turns=max_turns)
                 except retryable as fallback_error:
                     logger.warning(
                         f"Fallback model '{fallback_model}' also failed: {fallback_error}"
@@ -739,7 +744,14 @@ class Agentor(AgentorBase):
         """
 
         async def stream(input: str) -> AsyncIterator[AgentOutput]:
-            async for event in self._loop.astream(input):
+            # a streamed run is as resumable as a non-streamed one, but only if
+            # it is given a run id to persist under
+            run_id = None
+            if self._loop.store is not None:
+                from agentor.engine.store import new_run_id
+
+                run_id = new_run_id()
+            async for event in self._loop.astream(input, run_id=run_id):
                 if event.type == "message":
                     yield AgentOutput(type="run_item_stream_event", message=event.text)
                 elif event.type == "tool_call":

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -554,7 +554,7 @@ class Agentor(AgentorBase):
         if isinstance(input, list):
             if isinstance(input[0], dict):
                 if self.engine == "native":
-                    return await self._loop.arun(input)
+                    return await self._loop.arun(input, max_turns=max_turns)
                 return await Runner.run(self.agent, input, context=CelestoConfig())
 
             futures = []

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -66,6 +66,31 @@ def _litellm_model_cls() -> type["LitellmModel"]:
     return LitellmModel
 
 
+def _adapt_mcp_server(server: MCPServerStreamableHttp):
+    """Wrap an openai-agents MCP server as a native engine MCPServer.
+
+    Only the connection parameters are reused; the native client speaks to the
+    server through the official `mcp` package.
+    """
+    from agentor.engine.mcp import MCPServer
+
+    params = getattr(server, "params", None) or {}
+    url = (
+        params.get("url") if isinstance(params, dict) else getattr(params, "url", None)
+    )
+    if not url:
+        raise ValueError(f"MCP server {server!r} has no url to connect to.")
+
+    headers = params.get("headers") if isinstance(params, dict) else None
+    timeout = (params.get("timeout") if isinstance(params, dict) else None) or 30.0
+    return MCPServer(
+        url=url,
+        headers=headers,
+        timeout=float(timeout),
+        name=getattr(server, "name", None) or url,
+    )
+
+
 def _retryable_errors() -> tuple[type[BaseException], ...]:
     """Error types worth retrying on a fallback model.
 
@@ -228,6 +253,7 @@ class Agentor(AgentorBase):
                 max_turns=max_turns,
                 enable_tracing=enable_tracing,
                 store=store,
+                output_type=output_type,
             )
             return
 
@@ -284,6 +310,7 @@ class Agentor(AgentorBase):
         max_turns: int,
         enable_tracing: bool,
         store: Any = None,
+        output_type: Any = None,
     ) -> None:
         """Set up the native engine (see agentor.engine)."""
         from agentor.engine import AgentLoop
@@ -293,20 +320,22 @@ class Agentor(AgentorBase):
         self.instructions = instructions
         self.api_key = api_key
         self.agent = None
-        self.mcp_servers = []
         self.enable_tracing = enable_tracing
         tracer = self._native_tracer(enable_tracing)
 
+        # openai-agents MCP servers are accepted and adapted, so the same
+        # Agentor(...) call works on either engine.
+        plain_tools, mcp_servers = [], []
         for tool in tools or []:
             if isinstance(tool, MCPServerStreamableHttp):
-                raise NotImplementedError(
-                    "MCP servers are not supported by engine='native' yet. "
-                    "Use engine='agents' for MCP-backed tools."
-                )
+                mcp_servers.append(_adapt_mcp_server(tool))
+            else:
+                plain_tools.append(tool)
 
         # Fail loudly rather than silently dropping a tool the caller passed.
-        self._tools = resolve_tools(tools)
+        self._tools = resolve_tools(plain_tools)
         self.tools = self._tools
+        self.mcp_servers = mcp_servers
 
         params: Dict[str, Any] = {}
         for field in ("temperature", "top_p", "max_tokens"):
@@ -325,6 +354,8 @@ class Agentor(AgentorBase):
             api_key=api_key,
             tracer=tracer,
             store=store,
+            mcp_servers=mcp_servers,
+            output_type=output_type,
             **params,
         )
 
@@ -710,9 +741,7 @@ class Agentor(AgentorBase):
         async def stream(input: str) -> AsyncIterator[AgentOutput]:
             async for event in self._loop.astream(input):
                 if event.type == "message":
-                    yield AgentOutput(
-                        type="run_item_stream_event", message=event.text
-                    )
+                    yield AgentOutput(type="run_item_stream_event", message=event.text)
                 elif event.type == "tool_call":
                     yield AgentOutput(
                         type="run_item_stream_event",

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -94,16 +94,21 @@ def _adapt_mcp_server(server: MCPServerStreamableHttp):
 def _retryable_errors() -> tuple[type[BaseException], ...]:
     """Error types worth retrying on a fallback model.
 
-    litellm's errors are only included when litellm is already loaded. That is
-    sufficient: the only way an agent can raise them is via LitellmModel, which
-    imports litellm itself. Probing `sys.modules` avoids forcing the import on
-    the OpenAI-only path.
+    litellm's errors are only included when litellm is already loaded, which
+    avoids forcing a ~1s import on the OpenAI-only path. Call this when an
+    error is in hand, never up front: litellm is imported lazily on its first
+    request, so a tuple built before that call would omit its errors and the
+    very first rate limit would skip the fallbacks entirely.
     """
     errors: list[type[BaseException]] = [openai.RateLimitError, openai.APIError]
     litellm = sys.modules.get("litellm")
     if litellm is not None:
         errors.extend([litellm.RateLimitError, litellm.APIError])
     return tuple(errors)
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    return isinstance(exc, _retryable_errors())
 
 
 class ToolFunctionParameters(TypedDict, total=False):
@@ -651,11 +656,10 @@ class Agentor(AgentorBase):
         Swapping the model is a copy of the loop rather than a rebuilt agent,
         because the model is not baked into the agent here.
         """
-        retryable = _retryable_errors()
         try:
             return await self._loop.arun(task, max_turns=max_turns)
-        except retryable as e:
-            if not fallback_models:
+        except Exception as e:
+            if not _is_retryable(e) or not fallback_models:
                 raise
             logger.warning(
                 f"Primary model failed with {type(e).__name__}: {e}. "
@@ -666,7 +670,9 @@ class Agentor(AgentorBase):
                     return await self._loop.with_model(
                         fallback_model, api_key=self.api_key
                     ).arun(task, max_turns=max_turns)
-                except retryable as fallback_error:
+                except Exception as fallback_error:
+                    if not _is_retryable(fallback_error):
+                        raise
                     logger.warning(
                         f"Fallback model '{fallback_model}' also failed: {fallback_error}"
                     )

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -42,6 +42,17 @@ def _strictify(node: Any) -> Any:
         node["type"] = node.get("type", "object")
         node["additionalProperties"] = False
         node["required"] = list(node["properties"])
+    elif node.get("type") == "object" and isinstance(
+        node.get("additionalProperties"), dict
+    ):
+        # An open map (dict[str, X]) has no fixed properties, and strict mode
+        # requires every object to enumerate them. No normalisation makes this
+        # legal, so fail here rather than on a provider 400 mid-run.
+        raise TypeError(
+            "output_type contains a dict/mapping field, which OpenAI strict "
+            "structured output cannot express. Model the keys explicitly, or "
+            "use a list of key/value objects."
+        )
     return node
 
 
@@ -295,9 +306,24 @@ class AgentLoop:
                     # is worse; the run is still returned to the caller.
                     logger.error("Failed to persist event for run %s: %s", run_id, e)
 
+        # Emitted before MCP setup: a failure there would otherwise leave a log
+        # with no run_start, and so no input to resume from.
+        messages = self._initial_messages(input)
+        start = Event(
+            type="run_start",
+            agent=self.name,
+            model=getattr(self.model, "model", None),
+            started_at=run_started,
+            messages=[dict(m) for m in messages],
+        )
+        record(start)
+        yield start
+
         try:
             async with self._connected_mcp_tools() as tools:
-                async for event in self._astream(input, stream_text, tools, max_turns):
+                async for event in self._astream(
+                    messages, stream_text, tools, max_turns
+                ):
                     record(event)
                     yield event
         except Exception as exc:
@@ -323,30 +349,19 @@ class AgentLoop:
 
     async def _astream(
         self,
-        input: MessageInput,
+        messages: List[Dict[str, Any]],
         stream_text: bool = False,
         tools: Optional[Dict[str, Tool]] = None,
         max_turns: Optional[int] = None,
     ) -> AsyncIterator[Event]:
         tools = self.tools if tools is None else tools
         turn_budget = self.max_turns if max_turns is None else max_turns
-        messages = self._initial_messages(input)
         failures: Dict[str, int] = {}
         disabled: set[str] = set()
         total = Usage()
 
         model_name = getattr(self.model, "model", None)
         run_started = time.time()
-
-        yield Event(
-            type="run_start",
-            agent=self.name,
-            model=model_name,
-            started_at=run_started,
-            # the input is recorded here so a crash before the first model
-            # response still leaves a resumable run
-            messages=[dict(m) for m in messages],
-        )
 
         for turn in range(1, turn_budget + 1):
             schemas = self._schemas(tools, disabled)
@@ -389,6 +404,10 @@ class AgentLoop:
 
             if not response.tool_calls:
                 text = response.content or ""
+                if self.output_type is not None:
+                    # validate before declaring success, or the log and the
+                    # trace record a completed run the caller saw raise
+                    self._parse_output(text)
                 yield Event(type="message", text=text, turn=turn, usage=response.usage)
                 yield Event(
                     type="run_end",

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import time
+from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from agentor.engine.events import Event, RunResult, Usage
@@ -20,6 +21,28 @@ from agentor.engine.tools import Tool, resolve_tools
 logger = logging.getLogger(__name__)
 
 MessageInput = Union[str, List[Dict[str, Any]]]
+
+
+def _response_format(output_type: Any) -> Optional[Dict[str, Any]]:
+    """Build an OpenAI json_schema response format from a pydantic model."""
+    if output_type is None:
+        return None
+    if not hasattr(output_type, "model_json_schema"):
+        raise TypeError(
+            f"output_type must be a pydantic BaseModel, got {output_type!r}."
+        )
+
+    schema = output_type.model_json_schema()
+    # strict json_schema mode rejects extra keys and requires every property
+    schema["additionalProperties"] = False
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": output_type.__name__,
+            "schema": schema,
+            "strict": True,
+        },
+    }
 
 
 class AgentLoop:
@@ -38,6 +61,8 @@ class AgentLoop:
         base_url: Optional[str] = None,
         tracer: Any = None,
         store: Any = None,
+        mcp_servers: Optional[List[Any]] = None,
+        output_type: Any = None,
         **model_params: Any,
     ):
         self.name = name
@@ -47,6 +72,9 @@ class AgentLoop:
         self.max_tool_failures = max_tool_failures
         self.tracer = tracer
         self.store = store
+        self.mcp_servers = list(mcp_servers or [])
+        self.output_type = output_type
+        self._response_format = _response_format(output_type)
         self.model: Model = resolve_model(
             model, api_key=api_key, base_url=base_url, **model_params
         )
@@ -165,6 +193,41 @@ class AgentLoop:
 
     # ------------------------------------------------------------ the loop
 
+    @asynccontextmanager
+    async def _connected_mcp_tools(self):
+        """Hold MCP connections open for one run and merge in their tools.
+
+        Connecting per run rather than per process keeps the loop usable from
+        short-lived workers, where a long-lived session would go stale.
+        """
+        if not self.mcp_servers:
+            yield
+            return
+
+        added: List[str] = []
+        connected: List[Any] = []
+        try:
+            for server in self.mcp_servers:
+                remote_tools = await server.connect()
+                connected.append(server)
+                for tool in remote_tools:
+                    if tool.name in self.tools:
+                        logger.warning(
+                            "MCP server %s exposes %r, which shadows an existing "
+                            "tool; use tool_prefix to disambiguate.",
+                            server.name,
+                            tool.name,
+                        )
+                        continue
+                    self.tools[tool.name] = tool
+                    added.append(tool.name)
+            yield
+        finally:
+            for name in added:
+                self.tools.pop(name, None)
+            for server in connected:
+                await server.close()
+
     async def astream(
         self,
         input: MessageInput,
@@ -178,20 +241,23 @@ class AgentLoop:
         """
         collector = self.tracer.collector(self.name) if self.tracer else None
 
-        async for event in self._astream(input, stream_text):
-            if collector is not None:
-                try:
-                    collector.handle(event)
-                except Exception as e:  # tracing must never break a run
-                    logger.warning("Trace collection failed: %s", e)
-            if self.store is not None and run_id is not None:
-                try:
-                    self.store.append(run_id, event)
-                except Exception as e:
-                    # Losing durability is bad, but killing a live run over it
-                    # is worse; the run is still returned to the caller.
-                    logger.error("Failed to persist event for run %s: %s", run_id, e)
-            yield event
+        async with self._connected_mcp_tools():
+            async for event in self._astream(input, stream_text):
+                if collector is not None:
+                    try:
+                        collector.handle(event)
+                    except Exception as e:  # tracing must never break a run
+                        logger.warning("Trace collection failed: %s", e)
+                if self.store is not None and run_id is not None:
+                    try:
+                        self.store.append(run_id, event)
+                    except Exception as e:
+                        # Losing durability is bad, but killing a live run over
+                        # it is worse; the run is still returned to the caller.
+                        logger.error(
+                            "Failed to persist event for run %s: %s", run_id, e
+                        )
+                yield event
 
         if collector is not None:
             try:
@@ -226,7 +292,10 @@ class AgentLoop:
 
             if stream_text:
                 response = None
-                async for chunk in self.model.stream(messages, schemas):
+                # only passed when set, so a Model adapter that predates
+                # structured output keeps working
+                extra = (self._response_format,) if self._response_format else ()
+                async for chunk in self.model.stream(messages, schemas, *extra):
                     if chunk.delta:
                         yield Event(type="text_delta", text=chunk.delta, turn=turn)
                     if chunk.final is not None:
@@ -234,7 +303,8 @@ class AgentLoop:
                 if response is None:
                     response = ModelResponse()
             else:
-                response = await self.model.complete(messages, schemas)
+                extra = (self._response_format,) if self._response_format else ()
+                response = await self.model.complete(messages, schemas, *extra)
 
             total = total + response.usage
             assistant = self._assistant_message(response)
@@ -343,7 +413,23 @@ class AgentLoop:
                 result.final_output = event.text
                 result.usage = event.usage or Usage()
                 result.error = event.error
+
+        # Events stay plain text so the log remains JSON-serialisable; only the
+        # returned result carries the parsed object.
+        if self.output_type is not None and result.status == "completed":
+            result.final_output = self._parse_output(result.final_output)
         return result
+
+    def _parse_output(self, text: Optional[str]) -> Any:
+        if not text:
+            return None
+        try:
+            return self.output_type.model_validate_json(text)
+        except Exception as e:
+            raise ValueError(
+                f"Model output did not match {self.output_type.__name__}: {e}\n"
+                f"Raw output: {text[:500]}"
+            ) from e
 
     def run(self, input: MessageInput, run_id: Optional[str] = None) -> RunResult:
         return self._sync(self.arun(input, run_id=run_id))

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -23,6 +23,38 @@ logger = logging.getLogger(__name__)
 MessageInput = Union[str, List[Dict[str, Any]]]
 
 
+def _strictify(node: Any) -> Any:
+    """Make a JSON schema satisfy OpenAI\'s strict json_schema rules.
+
+    Strict mode requires every object - including nested ones and `$defs` - to
+    set `additionalProperties: false` and to list every property in `required`.
+    Setting it only on the root gets otherwise valid models rejected before
+    generation. Optional fields are already emitted as nullable unions by
+    pydantic, so listing them as required is correct.
+    """
+    if isinstance(node, list):
+        return [_strictify(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    node = {key: _strictify(value) for key, value in node.items()}
+    if isinstance(node.get("properties"), dict):
+        node["type"] = node.get("type", "object")
+        node["additionalProperties"] = False
+        node["required"] = list(node["properties"])
+    return node
+
+
+def _clone_server(server: Any) -> Any:
+    """Build a fresh, unconnected copy of an MCP server template."""
+    clone = object.__new__(type(server))
+    clone.__dict__.update(server.__dict__)
+    clone._stack = None
+    clone._session = None
+    clone._loop = None
+    return clone
+
+
 def _response_format(output_type: Any) -> Optional[Dict[str, Any]]:
     """Build an OpenAI json_schema response format from a pydantic model."""
     if output_type is None:
@@ -32,9 +64,7 @@ def _response_format(output_type: Any) -> Optional[Dict[str, Any]]:
             f"output_type must be a pydantic BaseModel, got {output_type!r}."
         )
 
-    schema = output_type.model_json_schema()
-    # strict json_schema mode rejects extra keys and requires every property
-    schema["additionalProperties"] = False
+    schema = _strictify(output_type.model_json_schema())
     return {
         "type": "json_schema",
         "json_schema": {
@@ -117,17 +147,22 @@ class AgentLoop:
             ]
         return message
 
-    def _schemas(self, disabled: set[str]) -> Optional[List[Dict[str, Any]]]:
-        schemas = [
-            t.to_openai() for name, t in self.tools.items() if name not in disabled
-        ]
+    @staticmethod
+    def _schemas(
+        tools: Dict[str, Tool], disabled: set[str]
+    ) -> Optional[List[Dict[str, Any]]]:
+        schemas = [t.to_openai() for name, t in tools.items() if name not in disabled]
         return schemas or None
 
     # ------------------------------------------------------------ execution
 
     async def _run_tool(
-        self, call: ToolCall, disabled: set[str] = frozenset()
+        self,
+        call: ToolCall,
+        tools: Optional[Dict[str, Tool]] = None,
+        disabled: set[str] = frozenset(),
     ) -> Event:
+        tools = self.tools if tools is None else tools
         try:
             args = json.loads(call.arguments or "{}")
         except json.JSONDecodeError as exc:
@@ -152,9 +187,9 @@ class AgentLoop:
                 result=f"Error: tool {call.name!r} is disabled after repeated failures.",
             )
 
-        tool = self.tools.get(call.name)
+        tool = tools.get(call.name)
         if tool is None:
-            known = ", ".join(sorted(self.tools)) or "none"
+            known = ", ".join(sorted(tools)) or "none"
             return Event(
                 type="tool_result",
                 name=call.name,
@@ -195,23 +230,29 @@ class AgentLoop:
 
     @asynccontextmanager
     async def _connected_mcp_tools(self):
-        """Hold MCP connections open for one run and merge in their tools.
+        """Yield the tool map for one run, with MCP tools merged in.
 
-        Connecting per run rather than per process keeps the loop usable from
-        short-lived workers, where a long-lived session would go stale.
+        The map is built per run and `self.tools` is never mutated: concurrent
+        runs on one loop (which `Agentor.arun` does for a batch of prompts)
+        would otherwise remove each other\'s remote tools mid-flight.
+
+        A fresh `MCPServer` is built per run for the same reason - the server
+        object holds a live session, so sharing one across concurrent runs
+        would let the first to finish close a session another is still using.
         """
         if not self.mcp_servers:
-            yield
+            yield dict(self.tools)
             return
 
-        added: List[str] = []
+        tools = dict(self.tools)
         connected: List[Any] = []
         try:
-            for server in self.mcp_servers:
+            for template in self.mcp_servers:
+                server = _clone_server(template)
                 remote_tools = await server.connect()
                 connected.append(server)
                 for tool in remote_tools:
-                    if tool.name in self.tools:
+                    if tool.name in tools:
                         logger.warning(
                             "MCP server %s exposes %r, which shadows an existing "
                             "tool; use tool_prefix to disambiguate.",
@@ -219,12 +260,9 @@ class AgentLoop:
                             tool.name,
                         )
                         continue
-                    self.tools[tool.name] = tool
-                    added.append(tool.name)
-            yield
+                    tools[tool.name] = tool
+            yield tools
         finally:
-            for name in added:
-                self.tools.pop(name, None)
             for server in connected:
                 await server.close()
 
@@ -233,6 +271,7 @@ class AgentLoop:
         input: MessageInput,
         stream_text: bool = False,
         run_id: Optional[str] = None,
+        max_turns: Optional[int] = None,
     ) -> AsyncIterator[Event]:
         """Run the agent, emitting every event, tracing and persisting it.
 
@@ -240,34 +279,57 @@ class AgentLoop:
         trace from being exported; `arun` always drains it.
         """
         collector = self.tracer.collector(self.name) if self.tracer else None
+        run_started = time.time()
 
-        async with self._connected_mcp_tools():
-            async for event in self._astream(input, stream_text):
-                if collector is not None:
-                    try:
-                        collector.handle(event)
-                    except Exception as e:  # tracing must never break a run
-                        logger.warning("Trace collection failed: %s", e)
-                if self.store is not None and run_id is not None:
-                    try:
-                        self.store.append(run_id, event)
-                    except Exception as e:
-                        # Losing durability is bad, but killing a live run over
-                        # it is worse; the run is still returned to the caller.
-                        logger.error(
-                            "Failed to persist event for run %s: %s", run_id, e
-                        )
-                yield event
+        def record(event: Event) -> None:
+            if collector is not None:
+                try:
+                    collector.handle(event)
+                except Exception as e:  # tracing must never break a run
+                    logger.warning("Trace collection failed: %s", e)
+            if self.store is not None and run_id is not None:
+                try:
+                    self.store.append(run_id, event)
+                except Exception as e:
+                    # Losing durability is bad, but killing a live run over it
+                    # is worse; the run is still returned to the caller.
+                    logger.error("Failed to persist event for run %s: %s", run_id, e)
 
-        if collector is not None:
-            try:
-                await asyncio.to_thread(self.tracer.export, collector)
-            except Exception as e:
-                logger.warning("Trace export failed: %s", e)
+        try:
+            async with self._connected_mcp_tools() as tools:
+                async for event in self._astream(input, stream_text, tools, max_turns):
+                    record(event)
+                    yield event
+        except Exception as exc:
+            # A failed run is exactly the one worth tracing, and a durable log
+            # without a terminal event cannot be told apart from a run still in
+            # flight. Emit one, then re-raise.
+            failure = Event(
+                type="run_end",
+                status="failed",
+                error=f"{type(exc).__name__}: {exc}",
+                started_at=run_started,
+                ended_at=time.time(),
+            )
+            record(failure)
+            yield failure
+            raise
+        finally:
+            if collector is not None:
+                try:
+                    await asyncio.to_thread(self.tracer.export, collector)
+                except Exception as e:
+                    logger.warning("Trace export failed: %s", e)
 
     async def _astream(
-        self, input: MessageInput, stream_text: bool = False
+        self,
+        input: MessageInput,
+        stream_text: bool = False,
+        tools: Optional[Dict[str, Tool]] = None,
+        max_turns: Optional[int] = None,
     ) -> AsyncIterator[Event]:
+        tools = self.tools if tools is None else tools
+        turn_budget = self.max_turns if max_turns is None else max_turns
         messages = self._initial_messages(input)
         failures: Dict[str, int] = {}
         disabled: set[str] = set()
@@ -281,10 +343,13 @@ class AgentLoop:
             agent=self.name,
             model=model_name,
             started_at=run_started,
+            # the input is recorded here so a crash before the first model
+            # response still leaves a resumable run
+            messages=[dict(m) for m in messages],
         )
 
-        for turn in range(1, self.max_turns + 1):
-            schemas = self._schemas(disabled)
+        for turn in range(1, turn_budget + 1):
+            schemas = self._schemas(tools, disabled)
             # snapshot before the call: `messages` is appended to below, and a
             # trace needs the request as it was actually sent
             request_messages = [dict(m) for m in messages]
@@ -350,7 +415,7 @@ class AgentLoop:
                 )
 
             results = await asyncio.gather(
-                *(self._run_tool(call, disabled) for call in response.tool_calls)
+                *(self._run_tool(call, tools, disabled) for call in response.tool_calls)
             )
 
             for event in results:
@@ -366,7 +431,7 @@ class AgentLoop:
 
                 if (
                     event.error is None
-                    or event.name not in self.tools
+                    or event.name not in tools
                     or event.name in disabled
                 ):
                     continue
@@ -391,14 +456,17 @@ class AgentLoop:
         yield Event(
             type="run_end",
             status="max_turns",
-            error=f"Reached max_turns ({self.max_turns}) without a final answer.",
+            error=f"Reached max_turns ({turn_budget}) without a final answer.",
             usage=total,
             started_at=run_started,
             ended_at=time.time(),
         )
 
     async def arun(
-        self, input: MessageInput, run_id: Optional[str] = None
+        self,
+        input: MessageInput,
+        run_id: Optional[str] = None,
+        max_turns: Optional[int] = None,
     ) -> RunResult:
         if self.store is not None and run_id is None:
             from agentor.engine.store import new_run_id
@@ -406,7 +474,7 @@ class AgentLoop:
             run_id = new_run_id()
 
         result = RunResult(run_id=run_id)
-        async for event in self.astream(input, run_id=run_id):
+        async for event in self.astream(input, run_id=run_id, max_turns=max_turns):
             result.events.append(event)
             if event.type == "run_end":
                 result.status = event.status or "completed"
@@ -431,8 +499,13 @@ class AgentLoop:
                 f"Raw output: {text[:500]}"
             ) from e
 
-    def run(self, input: MessageInput, run_id: Optional[str] = None) -> RunResult:
-        return self._sync(self.arun(input, run_id=run_id))
+    def run(
+        self,
+        input: MessageInput,
+        run_id: Optional[str] = None,
+        max_turns: Optional[int] = None,
+    ) -> RunResult:
+        return self._sync(self.arun(input, run_id=run_id, max_turns=max_turns))
 
     async def aresume(self, run_id: str) -> RunResult:
         """Continue a persisted run from where it stopped.
@@ -456,9 +529,14 @@ class AgentLoop:
 
         if is_complete(events):
             end = final_event(events)
+            output = end.text if end else None
+            if self.output_type is not None:
+                # otherwise resume() returns a str for a finished run and a
+                # parsed model for one it had to continue
+                output = self._parse_output(output)
             return RunResult(
                 run_id=run_id,
-                final_output=end.text if end else None,
+                final_output=output,
                 status="completed",
                 events=events,
                 usage=total_usage(events),

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -292,7 +292,7 @@ class AgentLoop:
         collector = self.tracer.collector(self.name) if self.tracer else None
         run_started = time.time()
 
-        def record(event: Event) -> None:
+        async def record(event: Event) -> None:
             if collector is not None:
                 try:
                     collector.handle(event)
@@ -300,7 +300,10 @@ class AgentLoop:
                     logger.warning("Trace collection failed: %s", e)
             if self.store is not None and run_id is not None:
                 try:
-                    self.store.append(run_id, event)
+                    # FileStore fsyncs every event. Awaiting it on a worker
+                    # keeps ordering while leaving the event loop free for
+                    # other runs and streams.
+                    await asyncio.to_thread(self.store.append, run_id, event)
                 except Exception as e:
                     # Losing durability is bad, but killing a live run over it
                     # is worse; the run is still returned to the caller.
@@ -316,7 +319,7 @@ class AgentLoop:
             started_at=run_started,
             messages=[dict(m) for m in messages],
         )
-        record(start)
+        await record(start)
         yield start
 
         try:
@@ -324,7 +327,7 @@ class AgentLoop:
                 async for event in self._astream(
                     messages, stream_text, tools, max_turns
                 ):
-                    record(event)
+                    await record(event)
                     yield event
         except Exception as exc:
             # A failed run is exactly the one worth tracing, and a durable log
@@ -337,7 +340,7 @@ class AgentLoop:
                 started_at=run_started,
                 ended_at=time.time(),
             )
-            record(failure)
+            await record(failure)
             yield failure
             raise
         finally:
@@ -531,6 +534,12 @@ class AgentLoop:
 
         A completed run is returned as-is rather than re-executed, so calling
         this after a crash is safe whether or not the run had finished.
+
+        Not safe against concurrent resumes of the *same unfinished* run: two
+        callers can both see it as incomplete and continue it, re-running
+        side-effecting tools. The bundled stores are single-process and carry
+        no lease or lock; coordinate externally if several workers can recover
+        the same run.
         """
         if self.store is None:
             raise ValueError("resume() requires a store; pass store= to AgentLoop.")

--- a/src/agentor/engine/mcp.py
+++ b/src/agentor/engine/mcp.py
@@ -1,0 +1,149 @@
+"""MCP client for the native engine.
+
+Built on the official `mcp` package rather than an agent framework's wrapper,
+so remote tools become ordinary `Tool` objects and the rest of the engine does
+not need to know where a tool came from.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import AsyncExitStack
+from typing import Any, Dict, List, Optional
+
+from agentor.engine.tools import Tool
+
+logger = logging.getLogger(__name__)
+
+
+def _content_to_text(result: Any) -> str:
+    """Flatten an MCP CallToolResult into the string a tool returns."""
+    parts: List[str] = []
+    for item in getattr(result, "content", None) or []:
+        text = getattr(item, "text", None)
+        if text is not None:
+            parts.append(text)
+            continue
+        # non-text content (images, resources) still needs to reach the model
+        # as something; its own repr is better than dropping it silently
+        parts.append(str(getattr(item, "model_dump", lambda: item)()))
+
+    if not parts and getattr(result, "structuredContent", None) is not None:
+        return str(result.structuredContent)
+    return "\n".join(parts)
+
+
+class MCPServer:
+    """A streamable-HTTP MCP server whose tools an agent can call.
+
+    Usable directly as an async context manager, or handed to `AgentLoop`,
+    which connects it for the duration of a run.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: float = 30.0,
+        name: Optional[str] = None,
+        tool_prefix: Optional[str] = None,
+    ):
+        self.url = url
+        self.headers = headers
+        self.timeout = timeout
+        self.name = name or url
+        #: guards against two servers exposing the same tool name
+        self.tool_prefix = tool_prefix
+        self._stack: Optional[AsyncExitStack] = None
+        self._session: Any = None
+        self._loop: Any = None
+
+    async def connect(self) -> List[Tool]:
+        import asyncio
+
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        self._loop = asyncio.get_running_loop()
+        stack = AsyncExitStack()
+        try:
+            read, write, _ = await stack.enter_async_context(
+                streamablehttp_client(
+                    self.url, headers=self.headers, timeout=self.timeout
+                )
+            )
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+        except BaseException:
+            await stack.aclose()
+            raise
+
+        self._stack = stack
+        self._session = session
+        return await self.list_tools()
+
+    async def list_tools(self) -> List[Tool]:
+        if self._session is None:
+            raise RuntimeError(f"MCP server {self.name!r} is not connected.")
+
+        listed = await self._session.list_tools()
+        tools: List[Tool] = []
+        for remote in listed.tools:
+            name = (
+                f"{self.tool_prefix}{remote.name}" if self.tool_prefix else remote.name
+            )
+            tools.append(
+                Tool(
+                    name=name,
+                    description=remote.description or "",
+                    parameters=remote.inputSchema
+                    or {"type": "object", "properties": {}},
+                    invoke=self._invoker(remote.name),
+                )
+            )
+        return tools
+
+    def _invoker(self, remote_name: str):
+        async def invoke(**kwargs: Any) -> str:
+            result = await self._session.call_tool(remote_name, kwargs)
+            text = _content_to_text(result)
+            if getattr(result, "isError", False):
+                # raise so the loop's failure budget applies to remote tools too
+                raise RuntimeError(text or "MCP tool reported an error")
+            return text
+
+        return invoke
+
+    async def close(self) -> None:
+        if self._stack is None:
+            return
+
+        import asyncio
+
+        if self._loop is not None and self._loop is not asyncio.get_running_loop():
+            # anyio binds the session's cancel scope to the task that opened it.
+            # Closing from elsewhere raises "Attempted to exit cancel scope in a
+            # different task", which says nothing about the actual mistake.
+            self._stack = None
+            self._session = None
+            raise RuntimeError(
+                f"MCP server {self.name!r} was connected on a different event "
+                "loop than the one closing it. Connect and close within the "
+                "same asyncio.run(), or use `async with MCPServer(...)`."
+            )
+
+        try:
+            await self._stack.aclose()
+        except Exception as e:
+            logger.warning("Error closing MCP server %s: %s", self.name, e)
+        finally:
+            self._stack = None
+            self._session = None
+            self._loop = None
+
+    async def __aenter__(self) -> "MCPServer":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.close()

--- a/src/agentor/engine/mcp.py
+++ b/src/agentor/engine/mcp.py
@@ -74,13 +74,17 @@ class MCPServer:
             )
             session = await stack.enter_async_context(ClientSession(read, write))
             await session.initialize()
+            self._stack = stack
+            self._session = session
+            # Discovery stays inside the guard: if it raises after the session
+            # opens, connect() never returns, so nothing else can close it.
+            return await self.list_tools()
         except BaseException:
+            self._stack = None
+            self._session = None
+            self._loop = None
             await stack.aclose()
             raise
-
-        self._stack = stack
-        self._session = session
-        return await self.list_tools()
 
     async def list_tools(self) -> List[Tool]:
         if self._session is None:

--- a/src/agentor/engine/mcp.py
+++ b/src/agentor/engine/mcp.py
@@ -135,8 +135,8 @@ class MCPServer:
             # anyio binds the session's cancel scope to the task that opened it.
             # Closing from elsewhere raises "Attempted to exit cancel scope in a
             # different task", which says nothing about the actual mistake.
-            self._stack = None
-            self._session = None
+            # State is left intact so the caller can still close it correctly
+            # from the original loop; clearing it here would strand the session.
             raise RuntimeError(
                 f"MCP server {self.name!r} was connected on a different event "
                 "loop than the one closing it. Connect and close within the "

--- a/src/agentor/engine/mcp.py
+++ b/src/agentor/engine/mcp.py
@@ -64,6 +64,13 @@ class MCPServer:
         from mcp import ClientSession
         from mcp.client.streamable_http import streamablehttp_client
 
+        if self._stack is not None:
+            # Overwriting _stack would make the first transport unclosable.
+            raise RuntimeError(
+                f"MCP server {self.name!r} is already connected. Call close() "
+                "first, or use a separate MCPServer per connection."
+            )
+
         self._loop = asyncio.get_running_loop()
         stack = AsyncExitStack()
         try:

--- a/src/agentor/engine/models.py
+++ b/src/agentor/engine/models.py
@@ -43,11 +43,17 @@ class StreamChunk:
 @runtime_checkable
 class Model(Protocol):
     async def complete(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> ModelResponse: ...
 
     def stream(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[StreamChunk]: ...
 
 
@@ -87,7 +93,10 @@ class ChatCompletionsModel:
             )
 
     def _request(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]]
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]],
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "model": self.model,
@@ -96,13 +105,18 @@ class ChatCompletionsModel:
         }
         if tools:
             payload["tools"] = tools
+        if response_format:
+            payload["response_format"] = response_format
         return payload
 
     async def complete(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> ModelResponse:
         raw = await self.client.chat.completions.create(
-            **self._request(messages, tools)
+            **self._request(messages, tools, response_format)
         )
         message = raw.choices[0].message
         return ModelResponse(
@@ -120,9 +134,12 @@ class ChatCompletionsModel:
         )
 
     async def stream(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[StreamChunk]:
-        request = self._request(messages, tools)
+        request = self._request(messages, tools, response_format)
         request["stream"] = True
         request["stream_options"] = {"include_usage": True}
 
@@ -189,7 +206,10 @@ class LiteLLMModel:
         self.params = params
 
     async def complete(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> ModelResponse:
         import litellm
 
@@ -198,6 +218,7 @@ class LiteLLMModel:
             messages=messages,
             tools=tools or None,
             api_key=self.api_key,
+            response_format=response_format,
             **self.params,
         )
         message = raw.choices[0].message
@@ -216,7 +237,10 @@ class LiteLLMModel:
         )
 
     async def stream(
-        self, messages: List[Dict[str, Any]], tools: Optional[List[Dict]] = None
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[StreamChunk]:
         # litellm mirrors the OpenAI streaming shape, so reuse that accumulator
         # rather than maintaining a second one.
@@ -235,7 +259,7 @@ class LiteLLMModel:
                         return await litellm.acompletion(api_key=self.api_key, **kwargs)
 
         model.client = _Shim()
-        async for chunk in model.stream(messages, tools):
+        async for chunk in model.stream(messages, tools, response_format):
             yield chunk
 
 

--- a/src/agentor/engine/store.py
+++ b/src/agentor/engine/store.py
@@ -160,9 +160,12 @@ def final_event(events: List[Event]) -> Optional[Event]:
 
 
 def total_usage(events: List[Event]) -> Usage:
-    end = final_event(events)
-    if end is not None and end.usage is not None:
-        return end.usage
+    """Sum every generation in the log.
+
+    Deliberately not the terminal event's usage: a resumed run has one
+    `run_end` per segment, and the last one counts only the continuation, so
+    reading it would silently drop everything spent before the resume.
+    """
     total = Usage()
     for event in events:
         if event.type == "generation" and event.usage:

--- a/src/agentor/engine/store.py
+++ b/src/agentor/engine/store.py
@@ -99,20 +99,38 @@ def replay_messages(events: List[Event]) -> List[Dict[str, Any]]:
     recent one plus its own reply and any tool results that followed is the
     full conversation. Nothing needs to be inferred.
     """
+    start: Optional[Event] = None
     last_generation: Optional[Event] = None
     trailing: List[Event] = []
 
     for event in events:
-        if event.type == "generation":
+        if event.type == "run_start" and start is None:
+            start = event
+        elif event.type == "generation":
             last_generation = event
             trailing = []
         elif event.type == "tool_result" and last_generation is not None:
             trailing.append(event)
 
     if last_generation is None:
-        return []
+        # Crashed before the first response; the input recorded at run_start is
+        # all that is needed to start over.
+        return [dict(m) for m in (start.messages or [])] if start else []
 
     messages: List[Dict[str, Any]] = [dict(m) for m in (last_generation.messages or [])]
+
+    requested = {
+        call.get("id") for call in (last_generation.calls or []) if call.get("id")
+    }
+    answered = {event.call_id for event in trailing if event.call_id}
+
+    if requested - answered:
+        # The run stopped between requesting tools and recording every result.
+        # Replaying the assistant turn would send tool_calls with no matching
+        # tool messages, which providers reject outright, and the unfinished
+        # tools would never run. Rewind to the request that produced it and let
+        # the model decide again.
+        return messages
 
     assistant: Dict[str, Any] = {"role": "assistant", "content": last_generation.text}
     if last_generation.calls:

--- a/src/agentor/engine/tools.py
+++ b/src/agentor/engine/tools.py
@@ -6,6 +6,7 @@ a `BaseTool` capability, an openai-agents `FunctionTool`, or a registry name.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import re
@@ -157,9 +158,15 @@ class Tool:
             # context too, or tools reading it silently receive None
             kwargs["__context__"] = context
 
-        result = self.invoke(**kwargs)
-        if inspect.isawaitable(result):
-            result = await result
+        if inspect.iscoroutinefunction(self.invoke):
+            result = await self.invoke(**kwargs)
+        else:
+            # Most BaseTool capabilities are sync and do blocking IO. Calling
+            # them inline would serialize the parallel tool calls the loop
+            # gathers, and stall every other coroutine on the loop with them.
+            result = await asyncio.to_thread(lambda: self.invoke(**kwargs))
+            if inspect.isawaitable(result):
+                result = await result
         return stringify(result)
 
     @classmethod

--- a/src/agentor/engine/tools.py
+++ b/src/agentor/engine/tools.py
@@ -135,6 +135,8 @@ class Tool:
     invoke: Callable[..., Any]
     #: parameter that receives the run context instead of model-supplied args
     context_param: Optional[str] = None
+    #: adapter builds its own context wrapper and wants the raw run context
+    wants_context: bool = False
 
     def to_openai(self) -> Dict[str, Any]:
         return {
@@ -150,6 +152,10 @@ class Tool:
         kwargs = dict(args)
         if self.context_param:
             kwargs[self.context_param] = _ContextWrapper(context)
+        if self.wants_context:
+            # adapters that build their own wrapper (FunctionTool) need the run
+            # context too, or tools reading it silently receive None
+            kwargs["__context__"] = context
 
         result = self.invoke(**kwargs)
         if inspect.isawaitable(result):
@@ -213,14 +219,28 @@ def _from_function_tool(ft: Any) -> Tool:
     """
     invoker = ft.on_invoke_tool
 
-    async def invoke(**kwargs: Any) -> Any:
-        return await invoker(_ContextWrapper(None), json.dumps(kwargs))
+    async def invoke(__context__: Any = None, **kwargs: Any) -> Any:
+        # openai-agents reads more than `.context` off this object (tool_name,
+        # run_config, usage), so build its real ToolContext rather than a
+        # duck-type. The import is local to this adapter: it exists only for
+        # openai-agents interop and goes away with it.
+        from agents.tool_context import ToolContext
+
+        arguments = json.dumps(kwargs)
+        context = ToolContext(
+            context=__context__,
+            tool_name=ft.name,
+            tool_call_id=f"call_{ft.name}",
+            tool_arguments=arguments,
+        )
+        return await invoker(context, arguments)
 
     return Tool(
         name=ft.name,
         description=ft.description or "",
         parameters=_strip_titles(dict(ft.params_json_schema or {})),
         invoke=invoke,
+        wants_context=True,
     )
 
 
@@ -245,7 +265,10 @@ def resolve_tools(tools: Optional[List[Any]]) -> List[Tool]:
             for attr_name, method in item.list_capabilities():
                 resolved.append(Tool.from_function(method, name=attr_name))
 
-        elif callable(item) and hasattr(item, "on_invoke_tool"):
+        # checked before `callable`: an openai-agents FunctionTool is a
+        # dataclass, so a `callable(item) and ...` guard never matches it and
+        # @function_tool tools would be rejected outright
+        elif hasattr(item, "on_invoke_tool"):
             resolved.append(_from_function_tool(item))
 
         elif callable(item):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,9 +4,11 @@ The loop is exercised against a scripted fake model so behaviour is asserted
 without network access.
 """
 
+import json
 from typing import Literal, Optional
 
 import pytest
+from pydantic import BaseModel
 
 from agentor.engine import AgentLoop, Tool, resolve_tools
 from agentor.engine.events import Usage
@@ -26,14 +28,20 @@ class FakeModel:
         self.responses = list(responses)
         self.calls = []
 
-    async def complete(self, messages, tools=None):
-        self.calls.append({"messages": [dict(m) for m in messages], "tools": tools})
+    async def complete(self, messages, tools=None, response_format=None):
+        self.calls.append(
+            {
+                "messages": [dict(m) for m in messages],
+                "tools": tools,
+                "response_format": response_format,
+            }
+        )
         if not self.responses:
             return ModelResponse(content="done")
         return self.responses.pop(0)
 
-    async def stream(self, messages, tools=None):
-        response = await self.complete(messages, tools)
+    async def stream(self, messages, tools=None, response_format=None):
+        response = await self.complete(messages, tools, response_format)
         for piece in (response.content or "").split(" "):
             yield StreamChunk(delta=piece + " ")
         yield StreamChunk(final=response)
@@ -408,6 +416,75 @@ def test_run_rejects_being_called_inside_event_loop():
     asyncio.run(main())
 
 
+# --------------------------------------------------------- structured output
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+@pytest.mark.asyncio
+async def test_output_type_parses_the_final_answer():
+    model = FakeModel(text('{"name": "Ada", "age": 36}'))
+    loop = AgentLoop(model=model, output_type=Person)
+    result = await loop.arun("who?")
+
+    assert isinstance(result.final_output, Person)
+    assert result.final_output.name == "Ada"
+
+
+@pytest.mark.asyncio
+async def test_output_type_sends_a_strict_json_schema():
+    model = FakeModel(text('{"name": "Ada", "age": 36}'))
+    await AgentLoop(model=model, output_type=Person).arun("who?")
+
+    fmt = model.calls[0]["response_format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["json_schema"]["name"] == "Person"
+    assert fmt["json_schema"]["strict"] is True
+    assert fmt["json_schema"]["schema"]["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+async def test_events_stay_serialisable_with_output_type():
+    """Parsing happens at the boundary so the persisted log stays JSON."""
+    model = FakeModel(text('{"name": "Ada", "age": 36}'))
+    result = await AgentLoop(model=model, output_type=Person).arun("who?")
+
+    end = next(e for e in result.events if e.type == "run_end")
+    assert isinstance(end.text, str)
+    json.loads(end.to_json())
+
+
+@pytest.mark.asyncio
+async def test_output_type_mismatch_raises_with_the_raw_text():
+    model = FakeModel(text("not json at all"))
+    loop = AgentLoop(model=model, output_type=Person)
+
+    with pytest.raises(ValueError, match="did not match Person"):
+        await loop.arun("who?")
+
+
+def test_output_type_must_be_a_pydantic_model():
+    with pytest.raises(TypeError, match="must be a pydantic BaseModel"):
+        AgentLoop(model=FakeModel(text("x")), output_type=dict)
+
+
+@pytest.mark.asyncio
+async def test_no_output_type_sends_no_response_format():
+    """A model adapter predating structured output must keep working."""
+
+    class TwoArgModel:
+        model = "old"
+
+        async def complete(self, messages, tools=None):
+            return ModelResponse(content="fine")
+
+    result = await AgentLoop(model=TwoArgModel()).arun("go")
+    assert result.final_output == "fine"
+
+
 # --------------------------------------------------- Agentor integration
 
 
@@ -459,12 +536,22 @@ async def test_agentor_native_chat_non_streaming():
     assert result.final_output == "answer"
 
 
-def test_agentor_native_rejects_mcp_servers_loudly():
+def test_agentor_native_adapts_mcp_servers():
+    """An openai-agents MCP server must work unchanged on the native engine."""
+    from agentor.engine.mcp import MCPServer
     from agentor.mcp import MCPServerStreamableHttp
 
-    server = MCPServerStreamableHttp(name="m", params={"url": "http://example"})
-    with pytest.raises(NotImplementedError, match="MCP servers"):
-        native(FakeModel(text("x")), tools=[server])
+    server = MCPServerStreamableHttp(
+        name="m", params={"url": "http://example/mcp", "headers": {"A": "b"}}
+    )
+    agent = native(FakeModel(text("x")), tools=[server])
+
+    (adapted,) = agent._loop.mcp_servers
+    assert isinstance(adapted, MCPServer)
+    assert adapted.url == "http://example/mcp"
+    assert adapted.headers == {"A": "b"}
+    # an MCP server is not a local tool
+    assert agent.tools == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_mcp.py
+++ b/tests/test_engine_mcp.py
@@ -1,0 +1,220 @@
+"""Tests for the native engine's MCP client (agentor.engine.mcp)."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from tests.test_engine import FakeModel, calls, text, weather
+
+from agentor.engine import AgentLoop
+from agentor.engine.mcp import MCPServer, _content_to_text
+
+
+def remote_tool(name, description="", schema=None):
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+class FakeSession:
+    """Stands in for an mcp ClientSession."""
+
+    def __init__(self, tools, results=None, is_error=False):
+        self._tools = tools
+        self._results = results or {}
+        self._is_error = is_error
+        self.calls = []
+
+    async def list_tools(self):
+        return SimpleNamespace(tools=self._tools)
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return SimpleNamespace(
+            content=[SimpleNamespace(text=self._results.get(name, "ok"))],
+            structuredContent=None,
+            isError=self._is_error,
+        )
+
+
+def connected(session) -> MCPServer:
+    server = MCPServer("http://example/mcp", name="fake")
+    server._session = session
+    server._stack = None
+    return server
+
+
+# ------------------------------------------------------------ content
+
+
+def test_content_to_text_joins_text_parts():
+    result = SimpleNamespace(
+        content=[SimpleNamespace(text="a"), SimpleNamespace(text="b")],
+        structuredContent=None,
+    )
+    assert _content_to_text(result) == "a\nb"
+
+
+def test_content_to_text_falls_back_to_structured_content():
+    result = SimpleNamespace(content=[], structuredContent={"k": 1})
+    assert _content_to_text(result) == "{'k': 1}"
+
+
+def test_content_to_text_keeps_non_text_content():
+    """Images and resources must reach the model as something, not vanish."""
+    blob = SimpleNamespace(text=None, model_dump=lambda: {"type": "image"})
+    result = SimpleNamespace(content=[blob], structuredContent=None)
+    assert "image" in _content_to_text(result)
+
+
+# ------------------------------------------------------------ discovery
+
+
+@pytest.mark.asyncio
+async def test_list_tools_maps_remote_schema():
+    schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+    server = connected(FakeSession([remote_tool("search", "Search things", schema)]))
+
+    (tool,) = await server.list_tools()
+    assert tool.name == "search"
+    assert tool.description == "Search things"
+    assert tool.parameters == schema
+    assert tool.to_openai()["function"]["name"] == "search"
+
+
+@pytest.mark.asyncio
+async def test_tool_prefix_disambiguates_servers():
+    server = MCPServer("http://example/mcp", tool_prefix="a_")
+    server._session = FakeSession([remote_tool("search")])
+
+    (tool,) = await server.list_tools()
+    assert tool.name == "a_search"
+
+
+@pytest.mark.asyncio
+async def test_list_tools_requires_connection():
+    with pytest.raises(RuntimeError, match="not connected"):
+        await MCPServer("http://example/mcp").list_tools()
+
+
+@pytest.mark.asyncio
+async def test_calling_a_remote_tool_forwards_arguments():
+    session = FakeSession([remote_tool("search")], results={"search": "found it"})
+    server = connected(session)
+
+    (tool,) = await server.list_tools()
+    assert await tool.call({"q": "cats"}) == "found it"
+    assert session.calls == [("search", {"q": "cats"})]
+
+
+@pytest.mark.asyncio
+async def test_remote_error_raises_so_the_failure_budget_applies():
+    session = FakeSession([remote_tool("bad")], results={"bad": "upstream down"}, is_error=True)
+    server = connected(session)
+
+    (tool,) = await server.list_tools()
+    with pytest.raises(RuntimeError, match="upstream down"):
+        await tool.call({})
+
+
+# ------------------------------------------------------------ loop wiring
+
+
+@pytest.mark.asyncio
+async def test_remote_tools_are_available_during_a_run_and_removed_after():
+    session = FakeSession([remote_tool("remote_search")], results={"remote_search": "hit"})
+
+    class Server(MCPServer):
+        closed = False
+
+        async def connect(self):
+            self._session = session
+            return await self.list_tools()
+
+        async def close(self):
+            Server.closed = True
+
+    model = FakeModel(calls(("remote_search", '{"q": "x"}')), text("done"))
+    loop = AgentLoop(
+        model=model,
+        tools=[weather],
+        mcp_servers=[Server("http://example/mcp")],
+    )
+    result = await loop.arun("go")
+
+    assert result.final_output == "done"
+    assert [e.result for e in result.events if e.type == "tool_result"] == ["hit"]
+    # offered to the model during the run...
+    assert {t["function"]["name"] for t in model.calls[0]["tools"]} == {
+        "weather",
+        "remote_search",
+    }
+    # ...and gone afterwards, so the loop is reusable
+    assert sorted(loop.tools) == ["weather"]
+    assert Server.closed
+
+
+@pytest.mark.asyncio
+async def test_remote_tool_does_not_shadow_a_local_one():
+    session = FakeSession([remote_tool("weather")], results={"weather": "REMOTE"})
+
+    class Server(MCPServer):
+        async def connect(self):
+            self._session = session
+            return await self.list_tools()
+
+        async def close(self):
+            pass
+
+    model = FakeModel(calls(("weather", '{"city": "A"}')), text("done"))
+    loop = AgentLoop(
+        model=model, tools=[weather], mcp_servers=[Server("http://example/mcp")]
+    )
+    result = await loop.arun("go")
+
+    (event,) = [e for e in result.events if e.type == "tool_result"]
+    assert event.result == "A: sunny", "the local tool must win"
+
+
+@pytest.mark.asyncio
+async def test_servers_are_closed_even_when_a_run_fails():
+    class Server(MCPServer):
+        closed = False
+
+        async def connect(self):
+            self._session = FakeSession([remote_tool("x")])
+            return await self.list_tools()
+
+        async def close(self):
+            Server.closed = True
+
+    class Exploding:
+        model = "boom"
+
+        async def complete(self, messages, tools=None):
+            raise RuntimeError("model exploded")
+
+    loop = AgentLoop(model=Exploding(), mcp_servers=[Server("http://example/mcp")])
+    with pytest.raises(RuntimeError, match="model exploded"):
+        await loop.arun("go")
+
+    assert Server.closed, "a failed run must not leak connections"
+
+
+def test_closing_from_a_different_event_loop_explains_itself():
+    """anyio's own error names cancel scopes, not the actual mistake."""
+    server = MCPServer("http://example/mcp", name="fake")
+
+    async def connect():
+        server._loop = asyncio.get_running_loop()
+        server._stack = object()
+
+    asyncio.run(connect())
+
+    async def close():
+        await server.close()
+
+    with pytest.raises(RuntimeError, match="different event loop"):
+        asyncio.run(close())

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -228,9 +228,7 @@ async def test_mcp_transport_is_closed_when_discovery_fails(monkeypatch):
 
     @contextlib.asynccontextmanager
     async def fake_session(read, write):
-        session = type(
-            "S", (), {"initialize": lambda self: asyncio.sleep(0)}
-        )()
+        session = type("S", (), {"initialize": lambda self: asyncio.sleep(0)})()
         try:
             yield session
         finally:
@@ -420,3 +418,122 @@ async def test_function_tool_adapter_receives_the_run_context():
     await loop.arun("go")
 
     assert seen["context"] is sentinel
+
+
+# ============================================ second review round
+
+
+@pytest.mark.asyncio
+async def test_input_is_persisted_when_mcp_setup_fails():
+    """MCP failure happens before the loop starts; the input must survive it."""
+
+    class Unreachable(MCPServer):
+        async def connect(self):
+            raise ConnectionError("mcp server unreachable")
+
+        async def close(self):
+            pass
+
+    store = MemoryStore()
+    loop = AgentLoop(
+        model=FakeModel(text("never runs")),
+        store=store,
+        mcp_servers=[Unreachable("http://example/mcp")],
+    )
+
+    with pytest.raises(ConnectionError):
+        await loop.arun("do not lose this")
+
+    (run_id,) = store.list_runs()
+    events = store.load(run_id)
+    assert [e.type for e in events] == ["run_start", "run_end"]
+    assert replay_messages(events)[-1]["content"] == "do not lose this"
+
+
+@pytest.mark.asyncio
+async def test_run_is_resumable_after_an_mcp_setup_failure():
+    class Unreachable(MCPServer):
+        async def connect(self):
+            raise ConnectionError("down")
+
+        async def close(self):
+            pass
+
+    store = MemoryStore()
+    with pytest.raises(ConnectionError):
+        await AgentLoop(
+            model=FakeModel(),
+            store=store,
+            mcp_servers=[Unreachable("http://example/mcp")],
+        ).arun("question")
+
+    (run_id,) = store.list_runs()
+    recovered = await AgentLoop(model=FakeModel(text("ok")), store=store).aresume(
+        run_id
+    )
+    assert recovered.final_output == "ok"
+
+
+@pytest.mark.asyncio
+async def test_invalid_structured_output_is_recorded_as_a_failed_run():
+    """The caller saw an exception; the log must not claim success."""
+    store = MemoryStore()
+    tracer = RecordingTracer()
+    loop = AgentLoop(
+        model=FakeModel(text("this is not json")),
+        output_type=Optionals,
+        store=store,
+        tracer=tracer,
+    )
+
+    with pytest.raises(ValueError, match="did not match Optionals"):
+        await loop.arun("go")
+
+    (run_id,) = store.list_runs()
+    end = [e for e in store.load(run_id) if e.type == "run_end"]
+    assert [e.status for e in end] == ["failed"]
+
+    (items,) = tracer.exported
+    agent_span = next(i for i in items[1:] if i["span_data"]["type"] == "agent")
+    assert agent_span["span_data"]["status"] == "failed"
+
+
+def test_mapping_output_types_are_rejected_with_an_explanation():
+    """OpenAI strict mode cannot express an open map; fail before the request."""
+    from typing import Dict as TDict
+
+    class HasMap(BaseModel):
+        a: str
+        meta: TDict[str, str] = {}
+
+    with pytest.raises(TypeError, match="dict/mapping field"):
+        AgentLoop(model=FakeModel(text("x")), output_type=HasMap)
+
+
+def test_optional_defaults_are_left_alone():
+    """`default: null` is accepted by the API; stripping it would be churn."""
+    schema = _strictify(Optionals.model_json_schema())
+    assert schema["properties"]["b"]["default"] is None
+
+
+@pytest.mark.asyncio
+async def test_max_turns_is_honoured_for_message_list_input():
+    from agentor import Agentor
+
+    model = FakeModel(*[calls(("weather", '{"city": "X"}')) for _ in range(10)])
+    agent = Agentor(
+        name="T", model=model, tools=[weather], engine="native", api_key="test"
+    )
+    result = await agent.arun([{"role": "user", "content": "go"}], max_turns=2)
+
+    assert result.status == "max_turns"
+    assert len(model.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_connecting_twice_is_refused_rather_than_leaking():
+    server = MCPServer("http://example/mcp", name="dup")
+    server._stack = object()  # pretend a live connection
+
+    with pytest.raises(RuntimeError, match="already connected"):
+        await server.connect()

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -1,0 +1,422 @@
+"""Regression tests for the findings raised in the codex review of the v0.1.0 stack.
+
+Each test names the defect it pins down, so a future change that reintroduces
+one fails with an explanation rather than a bare assertion.
+"""
+
+import asyncio
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel
+
+from agentor.engine import AgentLoop
+from agentor.engine.events import Event
+from agentor.engine.loop import _strictify
+from agentor.engine.mcp import MCPServer
+from agentor.engine.store import MemoryStore, replay_messages
+from tests.test_engine import FakeModel, calls, text, weather
+from tests.test_engine_mcp import FakeSession, remote_tool
+
+
+class Boom:
+    """A model that always fails."""
+
+    model = "boom"
+
+    def __init__(self, message="provider down"):
+        self.message = message
+
+    async def complete(self, messages, tools=None, response_format=None):
+        raise RuntimeError(self.message)
+
+    async def stream(self, messages, tools=None, response_format=None):
+        raise RuntimeError(self.message)
+        yield  # pragma: no cover
+
+
+# ------------------------------------------------- P1: durability of the input
+
+
+@pytest.mark.asyncio
+async def test_input_is_persisted_before_the_first_model_call():
+    """A crash before the first response must still leave a resumable run."""
+    store = MemoryStore()
+    loop = AgentLoop(model=Boom(), store=store, instructions="sys")
+
+    with pytest.raises(RuntimeError):
+        await loop.arun("my important question")
+
+    (run_id,) = store.list_runs()
+    messages = replay_messages(store.load(run_id))
+    assert [m["role"] for m in messages] == ["system", "user"]
+    assert messages[-1]["content"] == "my important question"
+
+
+@pytest.mark.asyncio
+async def test_resume_after_a_pre_response_crash():
+    store = MemoryStore()
+    with pytest.raises(RuntimeError):
+        await AgentLoop(model=Boom(), store=store).arun("question")
+
+    (run_id,) = store.list_runs()
+    recovered = await AgentLoop(model=FakeModel(text("answer")), store=store).aresume(
+        run_id
+    )
+    assert recovered.final_output == "answer"
+
+
+# ------------------------------------------- P1: pending tool calls on resume
+
+
+def test_replay_rewinds_past_unanswered_tool_calls():
+    """Replaying tool_calls with no matching results is rejected by providers."""
+    events = [
+        Event(type="run_start", messages=[{"role": "user", "content": "q"}]),
+        Event(
+            type="generation",
+            messages=[{"role": "user", "content": "q"}],
+            calls=[
+                {
+                    "id": "c0",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": "{}"},
+                }
+            ],
+        ),
+        Event(type="tool_call", name="weather", call_id="c0"),
+    ]
+
+    messages = replay_messages(events)
+    assert [m["role"] for m in messages] == ["user"], (
+        "an assistant turn with unanswered tool_calls must not be replayed"
+    )
+
+
+def test_replay_rewinds_on_partially_answered_tool_calls():
+    events = [
+        Event(
+            type="generation",
+            messages=[{"role": "user", "content": "q"}],
+            calls=[
+                {
+                    "id": "c0",
+                    "type": "function",
+                    "function": {"name": "a", "arguments": "{}"},
+                },
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "b", "arguments": "{}"},
+                },
+            ],
+        ),
+        Event(type="tool_result", call_id="c0", name="a", result="done"),
+    ]
+    assert [m["role"] for m in replay_messages(events)] == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_resume_recovers_from_a_crash_between_call_and_result():
+    store = MemoryStore()
+    run_id = "r1"
+    for event in [
+        Event(type="run_start", messages=[{"role": "user", "content": "weather?"}]),
+        Event(
+            type="generation",
+            messages=[{"role": "user", "content": "weather?"}],
+            calls=[
+                {
+                    "id": "c0",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": '{"city": "Oslo"}'},
+                }
+            ],
+        ),
+        Event(type="tool_call", name="weather", call_id="c0"),
+    ]:
+        store.append(run_id, event)
+
+    model = FakeModel(calls(("weather", '{"city": "Oslo"}')), text("sunny"))
+    result = await AgentLoop(model=model, tools=[weather], store=store).aresume(run_id)
+
+    assert result.final_output == "sunny"
+    # the tool actually ran on resume rather than being skipped
+    assert any(
+        e.type == "tool_result" and e.result == "Oslo: sunny" for e in result.events
+    )
+
+
+# ------------------------------------------------ P1: MCP state across runs
+
+
+def make_server(session):
+    class Server(MCPServer):
+        connects = 0
+        closes = 0
+
+        async def connect(self):
+            Server.connects += 1
+            self._session = session
+            return await self.list_tools()
+
+        async def close(self):
+            Server.closes += 1
+
+    return Server
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_do_not_share_mcp_tool_state():
+    """Two runs on one loop must not strip each other's remote tools."""
+    Server = make_server(
+        FakeSession([remote_tool("remote")], results={"remote": "hit"})
+    )
+    loop = AgentLoop(
+        model=FakeModel(),
+        tools=[weather],
+        mcp_servers=[Server("http://example/mcp")],
+    )
+
+    async def one():
+        model = FakeModel(calls(("remote", "{}")), text("ok"))
+        loop_copy = loop.with_model(model)
+        result = await loop_copy.arun("go")
+        return [e.result for e in result.events if e.type == "tool_result"]
+
+    results = await asyncio.gather(*(one() for _ in range(6)))
+
+    assert all(r == ["hit"] for r in results), (
+        f"a concurrent run lost its remote tool: {results}"
+    )
+    # the shared loop's own tool map is never mutated
+    assert sorted(loop.tools) == ["weather"]
+    assert Server.connects == Server.closes
+
+
+@pytest.mark.asyncio
+async def test_each_run_gets_its_own_server_instance():
+    """Sharing one live session across runs lets the first finisher close it."""
+    Server = make_server(FakeSession([remote_tool("remote")]))
+    template = Server("http://example/mcp")
+    loop = AgentLoop(model=FakeModel(text("x")), mcp_servers=[template])
+
+    await loop.arun("go")
+    assert template._session is None, "the template must stay unconnected"
+
+
+@pytest.mark.asyncio
+async def test_mcp_transport_is_closed_when_discovery_fails(monkeypatch):
+    """If list_tools raises after connecting, the transport must not leak.
+
+    Exercises the real `connect()` against a faked transport rather than
+    reimplementing its logic here.
+    """
+    import contextlib
+
+    import mcp
+    import mcp.client.streamable_http as streamable
+
+    closed = []
+
+    @contextlib.asynccontextmanager
+    async def fake_transport(url, headers=None, timeout=None, **kwargs):
+        try:
+            yield (object(), object(), None)
+        finally:
+            closed.append("transport")
+
+    @contextlib.asynccontextmanager
+    async def fake_session(read, write):
+        session = type(
+            "S", (), {"initialize": lambda self: asyncio.sleep(0)}
+        )()
+        try:
+            yield session
+        finally:
+            closed.append("session")
+
+    monkeypatch.setattr(streamable, "streamablehttp_client", fake_transport)
+    monkeypatch.setattr(mcp, "ClientSession", fake_session)
+
+    class Failing(MCPServer):
+        async def list_tools(self):
+            raise RuntimeError("discovery exploded")
+
+    server = Failing("http://example/mcp")
+    with pytest.raises(RuntimeError, match="discovery exploded"):
+        await server.connect()
+
+    assert closed == ["session", "transport"], "the opened transport must be closed"
+    assert server._stack is None and server._session is None
+
+
+# ------------------------------------------------ P2: failure tracing
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.exported = []
+
+    def collector(self, workflow_name, **kwargs):
+        from agentor.engine.tracing import TraceCollector
+
+        return TraceCollector(workflow_name, **kwargs)
+
+    def export(self, collector):
+        self.exported.append(collector.items)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_run_is_still_traced():
+    """The runs worth tracing most are the ones that broke."""
+    tracer = RecordingTracer()
+    loop = AgentLoop(model=Boom("kaboom"), tracer=tracer)
+
+    with pytest.raises(RuntimeError):
+        await loop.arun("go")
+
+    (items,) = tracer.exported
+    agent_span = next(i for i in items[1:] if i["span_data"]["type"] == "agent")
+    assert agent_span["span_data"]["status"] == "failed"
+    assert "kaboom" in agent_span["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_run_gets_a_terminal_event_in_the_log():
+    """Without one, a crashed run is indistinguishable from one still running."""
+    store = MemoryStore()
+    with pytest.raises(RuntimeError):
+        await AgentLoop(model=Boom(), store=store).arun("go")
+
+    (run_id,) = store.list_runs()
+    end = [e for e in store.load(run_id) if e.type == "run_end"]
+    assert len(end) == 1
+    assert end[0].status == "failed"
+
+
+# ------------------------------------------------ P2: strict json schema
+
+
+class Nested(BaseModel):
+    z: int
+
+
+class Optionals(BaseModel):
+    a: str
+    b: Optional[int] = None
+    inner: Optional[Nested] = None
+
+
+def test_strictify_normalizes_nested_objects_and_defs():
+    schema = _strictify(Optionals.model_json_schema())
+
+    assert schema["additionalProperties"] is False
+    assert sorted(schema["required"]) == ["a", "b", "inner"]
+
+    nested = schema["$defs"]["Nested"]
+    assert nested["additionalProperties"] is False, "nested objects need it too"
+    assert nested["required"] == ["z"]
+
+
+@pytest.mark.asyncio
+async def test_optional_fields_survive_strict_mode():
+    model = FakeModel(text('{"a": "x", "b": null, "inner": null}'))
+    result = await AgentLoop(model=model, output_type=Optionals).arun("go")
+
+    assert result.final_output.a == "x"
+    assert result.final_output.b is None
+
+
+# ------------------------------------------------ P2: Agentor plumbing
+
+
+@pytest.mark.asyncio
+async def test_per_call_max_turns_is_honoured():
+    model = FakeModel(*[calls(("weather", '{"city": "X"}')) for _ in range(10)])
+    loop = AgentLoop(model=model, tools=[weather], max_turns=10)
+
+    result = await loop.arun("go", max_turns=2)
+    assert result.status == "max_turns"
+    assert "max_turns (2)" in result.error
+    assert len(model.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_agentor_arun_passes_max_turns_to_the_native_engine():
+    from agentor import Agentor
+
+    model = FakeModel(*[calls(("weather", '{"city": "X"}')) for _ in range(10)])
+    agent = Agentor(
+        name="T", model=model, tools=[weather], engine="native", api_key="test"
+    )
+    result = await agent.arun("go", max_turns=3)
+
+    assert result.status == "max_turns"
+    assert len(model.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_streamed_runs_are_persisted():
+    """A streamed run should be as resumable as a non-streamed one."""
+    from agentor import Agentor
+
+    store = MemoryStore()
+    agent = Agentor(
+        name="T",
+        model=FakeModel(text("streamed answer")),
+        engine="native",
+        api_key="test",
+        store=store,
+    )
+    _ = [chunk async for chunk in agent.stream_chat("go", serialize=False)]
+
+    (run_id,) = store.list_runs()
+    assert any(e.type == "run_end" for e in store.load(run_id))
+
+
+@pytest.mark.asyncio
+async def test_resume_of_a_completed_run_returns_the_parsed_output_type():
+    """resume() must not change return type based on whether it re-ran."""
+    store = MemoryStore()
+    loop = AgentLoop(
+        model=FakeModel(text('{"a": "x", "b": 1, "inner": null}')),
+        output_type=Optionals,
+        store=store,
+    )
+    first = await loop.arun("go")
+    assert isinstance(first.final_output, Optionals)
+
+    resumed = await loop.aresume(first.run_id)
+    assert isinstance(resumed.final_output, Optionals), (
+        "a finished run resumed to a raw JSON string instead of the model"
+    )
+    assert resumed.final_output.a == "x"
+
+
+# ------------------------------------------------ P2: FunctionTool context
+
+
+@pytest.mark.asyncio
+async def test_function_tool_adapter_receives_the_run_context():
+    """A FunctionTool reading ctx.context lost its credentials under native."""
+    from agents import RunContextWrapper, function_tool
+
+    seen = {}
+
+    @function_tool
+    async def needs_ctx(wrapper: RunContextWrapper, q: str) -> str:
+        """Doc.
+
+        Args:
+            q: query.
+        """
+        seen["context"] = wrapper.context
+        return "ok"
+
+    sentinel = object()
+    model = FakeModel(calls(("needs_ctx", '{"q": "x"}')), text("done"))
+    loop = AgentLoop(model=model, tools=[needs_ctx], context=sentinel)
+    await loop.arun("go")
+
+    assert seen["context"] is sentinel

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -14,7 +14,7 @@ from agentor.engine import AgentLoop
 from agentor.engine.events import Event
 from agentor.engine.loop import _strictify
 from agentor.engine.mcp import MCPServer
-from agentor.engine.store import MemoryStore, replay_messages
+from agentor.engine.store import MemoryStore, replay_messages, total_usage
 from tests.test_engine import FakeModel, calls, text, weather
 from tests.test_engine_mcp import FakeSession, remote_tool
 
@@ -537,3 +537,129 @@ async def test_connecting_twice_is_refused_rather_than_leaking():
 
     with pytest.raises(RuntimeError, match="already connected"):
         await server.connect()
+
+
+# ============================================ third review round
+
+
+@pytest.mark.asyncio
+async def test_sync_tools_run_in_parallel():
+    """Sync tools called inline serialize every gather and stall the loop."""
+    import time as _time
+
+    def slow(x: str) -> str:
+        """Slow.
+
+        Args:
+            x: anything.
+        """
+        _time.sleep(0.2)
+        return "done"
+
+    model = FakeModel(
+        calls(("slow", '{"x": "1"}'), ("slow", '{"x": "2"}'), ("slow", '{"x": "3"}')),
+        text("ok"),
+    )
+    loop = AgentLoop(model=model, tools=[slow])
+
+    started = _time.perf_counter()
+    await loop.arun("go")
+    elapsed = _time.perf_counter() - started
+
+    assert elapsed < 0.45, f"3x0.2s sync tools took {elapsed:.2f}s - serialized"
+
+
+@pytest.mark.asyncio
+async def test_the_event_loop_stays_responsive_during_a_sync_tool():
+    ticks = []
+
+    def blocking(x: str) -> str:
+        """Blocks.
+
+        Args:
+            x: anything.
+        """
+        import time as _time
+
+        _time.sleep(0.3)
+        return "done"
+
+    async def ticker():
+        for _ in range(10):
+            await asyncio.sleep(0.02)
+            ticks.append(1)
+
+    loop = AgentLoop(
+        model=FakeModel(calls(("blocking", '{"x": "1"}')), text("ok")),
+        tools=[blocking],
+    )
+    await asyncio.gather(loop.arun("go"), ticker())
+
+    assert len(ticks) == 10, "the event loop was blocked by a sync tool"
+
+
+def test_litellm_errors_are_resolved_when_the_error_is_raised():
+    """Building the tuple up front misses litellm's lazily imported errors."""
+    import sys
+
+    from agentor.core.agent import _is_retryable
+
+    litellm = sys.modules.get("litellm")
+    if litellm is None:  # pragma: no cover - depends on import order
+        import litellm  # noqa: F811
+
+    assert _is_retryable(litellm.RateLimitError("rate limited", "m", "p")), (
+        "a litellm rate limit must trigger the configured fallbacks"
+    )
+
+
+def test_usage_spans_resumed_segments():
+    """A resumed run has one run_end per segment; the last one is partial."""
+    from agentor.engine.events import Usage
+
+    events = [
+        Event(type="generation", usage=Usage(10, 20, 30)),
+        Event(type="run_end", status="max_turns", usage=Usage(10, 20, 30)),
+        Event(type="generation", usage=Usage(1, 2, 3)),
+        Event(type="run_end", status="completed", usage=Usage(1, 2, 3)),
+    ]
+    assert total_usage(events) == Usage(11, 22, 33)
+
+
+@pytest.mark.asyncio
+async def test_resumed_result_reports_total_usage():
+    store = MemoryStore()
+    first = await AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "X"}'))),
+        tools=[weather],
+        store=store,
+        max_turns=1,
+    ).arun("go")
+
+    await AgentLoop(
+        model=FakeModel(text("done")), tools=[weather], store=store
+    ).aresume(first.run_id)
+    resumed = await AgentLoop(model=FakeModel(), store=store).aresume(first.run_id)
+
+    assert resumed.usage.total_tokens == 6, "usage before the resume was dropped"
+
+
+def test_cross_loop_close_leaves_the_connection_recoverable():
+    """Clearing state before raising would strand the live transport."""
+    server = MCPServer("http://example/mcp", name="x")
+    stack = object()
+
+    async def pretend_connected():
+        server._loop = asyncio.get_running_loop()
+        server._stack = stack
+        server._session = object()
+
+    asyncio.run(pretend_connected())
+
+    async def close_from_another_loop():
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await server.close()
+
+    asyncio.run(close_from_another_loop())
+    assert server._stack is stack, "state must survive so cleanup can be retried"
+    assert server._session is not None

--- a/tests/test_engine_store.py
+++ b/tests/test_engine_store.py
@@ -3,7 +3,6 @@
 import json
 
 import pytest
-from tests.test_engine import FakeModel, calls, text, weather
 
 from agentor.engine import AgentLoop
 from agentor.engine.events import Event, Usage
@@ -14,6 +13,7 @@ from agentor.engine.store import (
     replay_messages,
     total_usage,
 )
+from tests.test_engine import FakeModel, calls, text, weather
 
 # ------------------------------------------------------------ serialization
 

--- a/tests/test_engine_tracing.py
+++ b/tests/test_engine_tracing.py
@@ -1,10 +1,10 @@
 """Tests for native-engine tracing (agentor.engine.tracing)."""
 
 import pytest
-from tests.test_engine import FakeModel, calls, text, weather
 
 from agentor.engine import AgentLoop
 from agentor.engine.tracing import CelestoTracer, TraceCollector
+from tests.test_engine import FakeModel, calls, text, weather
 
 
 class RecordingTracer:


### PR DESCRIPTION
Phase 5a of the v0.1.0 migration. **Stacked on #140 → #139 → #138 → #137.**

## Why 5a, not 5

Phase 5 was "close the gaps, flip the default, drop the dependency." Flipping the default engine changes behaviour for **every user** — that shouldn't ride along with the work that makes it possible, and definitely not on top of an unreviewed stack. So this closes the gaps; the flip is a separate, deliberate step.

## MCP

`agentor/engine/mcp.py` (150 LOC) on the **official `mcp` package**, not an agent framework's wrapper. Remote tools become ordinary `Tool` objects, so the loop, the failure budget and tracing apply to them with no special-casing.

- Connections held for the duration of a run, closed after — **including when the run raises** (tested).
- `Agentor(tools=[MCPServerStreamableHttp(...)])` is adapted automatically, so the same call works on either engine. Replaces the `NotImplementedError` from #138.
- A remote tool that would shadow a local one is skipped with a warning; `tool_prefix` disambiguates.

**Verified against a real server** — agentor's own LiteMCP, 9/9 checks: discovery, remote calls, local+remote tools in one run, cleanup, and MCP calls showing up as spans in traces.

## A debugging note worth reading

My first live MCP run passed 9/9 but printed `RuntimeError: Attempted to exit cancel scope in a different task`. Rather than accept a green result with an error in the output, I isolated it:

```
### A: connect+close in ONE event loop   → clean
### B: agent run in one event loop       → clean
### C: connect loop 1, close loop 2      → 1 error
```

**The bug was in my verification script**, which called `asyncio.run()` twice. The engine path was always clean. But it's a trap a user can hit, and anyio's message names the mechanism rather than the mistake — so `close()` now detects it and raises a message saying what to do instead.

## Structured output

`output_type=SomeModel` sends a strict `json_schema` response format and parses the result.

Parsing happens **at the boundary**: events keep plain text, so the persisted log stays JSON-serialisable. Durability and structured output don't interfere — asserted by a test that `json.loads` the `run_end` event.

`response_format` is only passed when set, so a `Model` adapter written before this keeps working (also tested, with a deliberately 2-arg model).

## Verification

- 18 new tests (12 MCP with a fake session, 6 structured output); `233 passed, 2 skipped`.
- Live: MCP 9/9 with zero stderr noise; structured output parsed correctly off a real call.
- Ruff clean on all new files.

## Still open before the flip (#5b)

- `WebSearchTool` / OpenAI hosted tools need a Responses adapter, or documenting as `engine="agents"` only.
- **Verify a non-OpenAI provider end to end.** `base_url` routing is still only verified against OpenAI's own endpoint — I have no third-party keys here. This is the biggest untested assumption in the whole plan and should be checked before the default changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up completes native-engine MCP and structured-output support while addressing the previously reported lifecycle and resume defects.
- Creates isolated MCP connections and tool maps for each run, with cleanup after discovery or execution failures.
- Adds strict Pydantic structured-output schemas while keeping persisted events JSON-serializable.
- Restores parsed structured output when resuming completed durable runs.
- Propagates per-call turn limits and improves durable streaming, replay, usage accounting, and tool adaptation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; MCP discovery now cleans up partial connections, concurrent runs use isolated sessions and tool maps, and completed durable resumes parse structured output consistently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/engine/loop.py | Adds per-run MCP isolation, structured-output validation, durable event recording, resume parsing, and per-call turn budgets; the reviewed prior defects are addressed. |
| src/agentor/engine/mcp.py | Implements the native MCP client with guarded discovery cleanup, tool adaptation, and event-loop-aware connection teardown. |
| src/agentor/engine/models.py | Extends native model adapters to pass structured response formats while preserving compatibility when none is configured. |
| src/agentor/core/agent.py | Integrates MCP server adaptation and structured output into the public native-engine API. |
| src/agentor/engine/store.py | Improves interrupted-run replay and computes usage across resumed execution segments. |
| src/agentor/engine/tools.py | Preserves FunctionTool context and moves synchronous tool invocation off the event loop. |

<sub>Reviews (4): Last reviewed commit: ["fix(engine): address third codex review ..."](https://github.com/celestoai/agentor/commit/b393b40789e149d6d0155d579869009b5276761b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48300400)</sub>

<!-- /greptile_comment -->