### PR TITLE
feat: expose base_url, verified against a third-party provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ print(result)
 agent.serve()
 ```
 
+### Any OpenAI-compatible provider
+
+Point `base_url` at any provider that speaks OpenAI's `/chat/completions` — OpenRouter,
+Groq, Together, Fireworks, DeepSeek, vLLM, Ollama, or Anthropic's and Gemini's compatible
+endpoints — with no extra dependency:
+
+```python
+agent = Agentor(
+    name="Assistant",
+    model="openrouter/auto",
+    base_url="https://openrouter.ai/api/v1",
+    api_key=os.environ["OPENROUTER_API_KEY"],
+    engine="native",
+)
+```
+
 Run the following command to query the Agent server:
 
 ```bash

--- a/docs/dev/MIGRATION_PLAN.md
+++ b/docs/dev/MIGRATION_PLAN.md
@@ -324,17 +324,54 @@ log stays JSON-serialisable — durability and structured output do not interfer
 
 233 tests passing.
 
+### Phase 5c — Multi-provider verified ✅ *shipped*
+
+**The plan's biggest untested assumption is now tested.** Everything the native engine does
+works against OpenRouter — a genuinely third-party, non-OpenAI endpoint — via `base_url` alone,
+12/12 checks:
+
+| | |
+|---|---|
+| completion + usage accounting | ✅ |
+| parallel tool calling | ✅ |
+| streaming, incl. tool calls reassembled from fragmented deltas | ✅ |
+| structured output — strict `json_schema`, nested models, optional fields | ✅ |
+| public `Agentor` API | ✅ |
+| **durable run interrupted and resumed against the third-party provider** | ✅ |
+
+Structured output surviving is the notable one: strict `json_schema` is the feature most likely
+to be unsupported downstream, and it worked.
+
+Verifying it exposed a gap that made the whole story unusable in practice: **`base_url` was not
+on the public API at all.** The pitch is "point `base_url` at any OpenAI-compatible provider",
+but reaching it meant constructing a `ChatCompletionsModel` by hand. It is now a first-class
+argument:
+
+```python
+agent = Agentor(
+    name="Assistant",
+    model="openrouter/auto",
+    base_url="https://openrouter.ai/api/v1",
+    api_key=os.environ["OPENROUTER_API_KEY"],
+    engine="native",
+)
+```
+
+Passing it with `engine="agents"` raises rather than being silently ignored, since openai-agents
+configures endpoints through its own client and would quietly disregard it. Without `base_url`, a
+`provider/model` string still routes to litellm exactly as before.
+
 ### Phase 5b — Flip the default and remove openai-agents (not started)
 
 Remaining before the flip:
 
 - `WebSearchTool` and other OpenAI hosted tools need a Responses API adapter, or to be documented
-  as `engine="agents"` only.
-- **Verify a non-OpenAI provider end to end.** `base_url` routing is verified only against
-  OpenAI's own endpoint; no third-party keys were available. This is the single biggest untested
-  assumption in the plan.
+  as `engine="agents"` only. This is now the last real blocker.
 - Then: flip the default, drop the dependency, delete the openai-agents half of
   `output_text_formatter.py` and `tracer.py`.
+
+Note that CI never ran on the v0.1.0 stack until it was about to merge: `test.yml` only triggered
+on `main`, so five PRs sat green on nothing but AI reviewers. Fixed in `e84fd3e`.
 
 **Total: ~2.5 weeks.**
 

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -211,6 +211,15 @@ class Agentor(AgentorBase):
     Use any model supported by LiteLLM, e.g. "gemini/gemini-pro" or "anthropic/claude-4".
         >>> agent = Agentor(name="Assistant", model="gemini/gemini-pro", api_key=os.environ.get("GEMINI_API_KEY"))
 
+    Or point base_url at any OpenAI-compatible endpoint (requires engine="native"):
+        >>> agent = Agentor(
+        ...     name="Assistant",
+        ...     model="openrouter/auto",
+        ...     base_url="https://openrouter.ai/api/v1",
+        ...     api_key=os.environ["OPENROUTER_API_KEY"],
+        ...     engine="native",
+        ... )
+
     Set model settings to configure the model behavior, e.g. temperature, top_p, etc.
         >>> from agentor import ModelSettings
         >>> model_settings = ModelSettings(temperature=0.5)
@@ -241,6 +250,7 @@ class Agentor(AgentorBase):
         engine: Literal["agents", "native"] = "agents",
         max_turns: int = 10,
         store: Any = None,
+        base_url: Optional[str] = None,
     ):
         if skills is not None:
             available_skills = self._inject_skills(skills)
@@ -259,8 +269,16 @@ class Agentor(AgentorBase):
                 enable_tracing=enable_tracing,
                 store=store,
                 output_type=output_type,
+                base_url=base_url,
             )
             return
+
+        if base_url is not None:
+            raise ValueError(
+                "base_url requires engine='native'. The openai-agents engine "
+                "configures endpoints through its own client, so honouring it "
+                "here would silently do nothing."
+            )
 
         super().__init__(name, instructions, model, api_key, enable_tracing)
         tools = tools or []
@@ -316,6 +334,7 @@ class Agentor(AgentorBase):
         enable_tracing: bool,
         store: Any = None,
         output_type: Any = None,
+        base_url: Optional[str] = None,
     ) -> None:
         """Set up the native engine (see agentor.engine)."""
         from agentor.engine import AgentLoop
@@ -357,6 +376,7 @@ class Agentor(AgentorBase):
             context=CelestoConfig(),
             max_turns=max_turns,
             api_key=api_key,
+            base_url=base_url,
             tracer=tracer,
             store=store,
             mcp_servers=mcp_servers,

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -663,3 +663,54 @@ def test_cross_loop_close_leaves_the_connection_recoverable():
     asyncio.run(close_from_another_loop())
     assert server._stack is stack, "state must survive so cleanup can be retried"
     assert server._session is not None
+
+
+# ============================================ multi-provider entry point
+
+
+def test_base_url_routes_to_the_chat_completions_adapter():
+    """The multi-provider story is unusable if base_url isn't on the public API."""
+    from agentor import Agentor
+    from agentor.engine.models import ChatCompletionsModel
+
+    agent = Agentor(
+        name="T",
+        model="openrouter/auto",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test",
+        engine="native",
+    )
+    assert isinstance(agent._loop.model, ChatCompletionsModel)
+    assert agent._loop.model.model == "openrouter/auto"
+
+
+def test_provider_prefixed_model_still_routes_to_litellm_without_base_url():
+    from agentor import Agentor
+    from agentor.engine.models import LiteLLMModel
+
+    agent = Agentor(
+        name="T", model="gemini/gemini-2.0-flash", api_key="test", engine="native"
+    )
+    assert isinstance(agent._loop.model, LiteLLMModel)
+
+
+def test_base_url_on_the_agents_engine_is_refused_not_ignored():
+    """Silently dropping it would look like the endpoint was honoured."""
+    from agentor import Agentor
+
+    with pytest.raises(ValueError, match="base_url requires engine='native'"):
+        Agentor(name="T", model="gpt-4o", base_url="https://example/v1", api_key="k")
+
+
+def test_model_settings_reach_the_native_model():
+    from agentor import Agentor, ModelSettings
+
+    agent = Agentor(
+        name="T",
+        model="gpt-4o-mini",
+        api_key="test",
+        engine="native",
+        model_settings=ModelSettings(temperature=0.2, max_tokens=400),
+    )
+    assert agent._loop.model.params["temperature"] == 0.2
+    assert agent._loop.model.params["max_tokens"] == 400


### PR DESCRIPTION
Closes the biggest untested assumption in the migration plan.

## The premise, finally tested

The whole case for demoting litellm to an optional adapter was: *pointing `base_url` at any OpenAI-compatible endpoint is enough*. Until now that was only ever verified against **OpenAI's own endpoint**, which proves nothing about compatibility.

Verified against **OpenRouter** — genuinely third-party — **12/12**:

| | |
|---|---|
| completion + usage accounting | ✅ |
| parallel tool calling (both tools, correct results fed back) | ✅ |
| streaming, incl. tool calls reassembled from fragmented deltas | ✅ |
| structured output — strict `json_schema`, nested models, optional fields | ✅ |
| public `Agentor` API | ✅ |
| **durable run interrupted at `max_turns` and resumed against that provider** | ✅ |

Structured output surviving is the one I expected to fail — strict `json_schema` is the feature most likely to be unsupported downstream. It worked.

## The gap that testing exposed

`base_url` **was not on the public API at all.** The headline pitch is "point `base_url` at any OpenAI-compatible provider," but actually reaching it meant constructing a `ChatCompletionsModel` by hand. The capability existed; the door didn't.

It's now a first-class argument:

```python
agent = Agentor(
    name="Assistant",
    model="openrouter/auto",
    base_url="https://openrouter.ai/api/v1",
    api_key=os.environ["OPENROUTER_API_KEY"],
    engine="native",
)
```

- Passing it with `engine="agents"` **raises** rather than being silently ignored — openai-agents configures endpoints through its own client and would quietly disregard it, which looks identical to it working.
- Without `base_url`, a `provider/model` string still routes to litellm exactly as before. No behaviour change.

## Verification

- `267 passed, 2 skipped` (4 new tests covering both routing paths and the refusal)
- Live: 12/12 against OpenRouter; OpenAI-side checks re-run and still green
- README and migration plan updated

## What's left before flipping the default

Only `WebSearchTool` / OpenAI hosted tools now — they need a Responses adapter or documenting as `engine="agents"` only. That's the last blocker for Phase 5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Exposes custom OpenAI-compatible endpoints through the public Agentor API.
- Adds and documents the native-engine `base_url` argument.
- Rejects `base_url` when using the agents engine.
- Adds tests for endpoint routing, preserved LiteLLM routing, rejection behavior, and native model settings.

<h3>Confidence Score: 3/5</h3>

The fallback endpoint-routing defect should be fixed before merging because a failed primary request can escape the explicitly configured provider.

The initial native model honors base_url, but fallback loops reconstruct their model without it, changing the selected adapter or sending requests to OpenAI's default endpoint.

**Files Needing Attention:** src/agentor/core/agent.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/core/agent.py | Adds public base_url routing and agents-engine validation, but fallback model construction loses the configured endpoint. |
| tests/test_engine_review_fixes.py | Covers initial adapter selection and refusal behavior but does not exercise base_url together with fallback_models. |
| README.md | Documents custom OpenAI-compatible endpoints using the native engine. |
| docs/dev/MIGRATION_PLAN.md | Records third-party-provider verification and the newly exposed endpoint configuration. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agentor with native engine] --> B{base_url supplied?}
    B -->|Yes| C[ChatCompletionsModel using custom endpoint]
    B -->|No, provider-prefixed model| D[LiteLLMModel]
    C --> E{Primary request succeeds?}
    E -->|Yes| F[Return result]
    E -->|No, fallback configured| G[Create fallback loop]
    G --> H[base_url omitted]
    H --> I[Default endpoint or LiteLLM routing]
```

<sub>Reviews (1): Last reviewed commit: ["feat: expose base\_url, verified against ..."](https://github.com/celestoai/agentor/commit/1d9553b63cc5691703c0530e887de61134595c20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48313092)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/celestoai/agentor/blob/main/AGENTS.md))

<!-- /greptile_comment -->