### PR TITLE
feat(engine): actionable error for provider-hosted tools

### DIFF
--- a/src/agentor/engine/tools.py
+++ b/src/agentor/engine/tools.py
@@ -281,6 +281,18 @@ def resolve_tools(tools: Optional[List[Any]]) -> List[Tool]:
         elif callable(item):
             resolved.append(Tool.from_function(item))
 
+        elif isinstance(getattr(item, "name", None), str):
+            # A provider-hosted tool: it carries a name but nothing to invoke,
+            # because the provider runs it server-side. The native engine talks
+            # to /chat/completions, which has no equivalent.
+            raise TypeError(
+                f"{type(item).__name__} is a provider-hosted tool "
+                f"({item.name!r}), which engine='native' cannot run: hosted "
+                "tools are executed by the provider through OpenAI's Responses "
+                "API. Use engine='agents' for it, or replace it with a regular "
+                "function tool."
+            )
+
         else:
             raise TypeError(
                 f"Unsupported tool type {type(item).__name__!r}. Expected a "

--- a/src/agentor/engine/tools.py
+++ b/src/agentor/engine/tools.py
@@ -282,15 +282,17 @@ def resolve_tools(tools: Optional[List[Any]]) -> List[Tool]:
             resolved.append(Tool.from_function(item))
 
         elif isinstance(getattr(item, "name", None), str):
-            # A provider-hosted tool: it carries a name but nothing to invoke,
-            # because the provider runs it server-side. The native engine talks
-            # to /chat/completions, which has no equivalent.
+            # Tool-shaped - it carries a name - but with nothing to invoke.
+            # That covers provider-hosted tools, whose body lives on the
+            # provider, and SDK-specific tool types whose execution is driven
+            # by a runner agentor does not use. The message deliberately does
+            # not assert which: both are unrunnable here, and guessing wrong
+            # sends the reader looking in the wrong place.
             raise TypeError(
-                f"{type(item).__name__} is a provider-hosted tool "
-                f"({item.name!r}), which engine='native' cannot run: hosted "
-                "tools are executed by the provider through OpenAI's Responses "
-                "API. Use engine='agents' for it, or replace it with a regular "
-                "function tool."
+                f"{type(item).__name__} ({item.name!r}) exposes no callable to "
+                "invoke, so agentor cannot run it. Provider-hosted tools (web "
+                "search, file search) and SDK-specific tool types are not "
+                "supported; define a function tool instead."
             )
 
         else:

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -714,3 +714,46 @@ def test_model_settings_reach_the_native_model():
     )
     assert agent._loop.model.params["temperature"] == 0.2
     assert agent._loop.model.params["max_tokens"] == 400
+
+
+# ============================================ provider-hosted tools
+
+
+def test_hosted_tools_fail_with_an_actionable_message():
+    """A generic 'unsupported type' hides why a documented tool stopped working."""
+    from agents import WebSearchTool
+
+    from agentor.engine.tools import resolve_tools
+
+    with pytest.raises(TypeError, match="provider-hosted tool") as exc:
+        resolve_tools([WebSearchTool()])
+
+    message = str(exc.value)
+    assert "web_search" in message
+    assert "engine='agents'" in message
+
+
+def test_agentor_surfaces_the_hosted_tool_message():
+    from agents import WebSearchTool
+
+    from agentor import Agentor
+
+    with pytest.raises(TypeError, match="provider-hosted tool"):
+        Agentor(
+            name="T",
+            model="gpt-4o-mini",
+            tools=[WebSearchTool()],
+            engine="native",
+            api_key="test",
+        )
+
+
+def test_hosted_tools_still_work_on_the_agents_engine():
+    from agents import WebSearchTool
+
+    from agentor import Agentor
+
+    agent = Agentor(
+        name="T", model="gpt-4o-mini", tools=[WebSearchTool()], api_key="test"
+    )
+    assert any(getattr(t, "name", None) == "web_search" for t in agent.tools)

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -719,26 +719,44 @@ def test_model_settings_reach_the_native_model():
 # ============================================ provider-hosted tools
 
 
-def test_hosted_tools_fail_with_an_actionable_message():
+def test_unrunnable_tools_fail_with_an_actionable_message():
     """A generic 'unsupported type' hides why a documented tool stopped working."""
     from agents import WebSearchTool
 
     from agentor.engine.tools import resolve_tools
 
-    with pytest.raises(TypeError, match="provider-hosted tool") as exc:
+    with pytest.raises(TypeError, match="no callable to invoke") as exc:
         resolve_tools([WebSearchTool()])
 
     message = str(exc.value)
     assert "web_search" in message
-    assert "engine='agents'" in message
+    assert "function tool" in message
 
 
-def test_agentor_surfaces_the_hosted_tool_message():
+def test_the_message_does_not_assert_the_wrong_execution_model():
+    """LocalShellTool and friends run locally, not on the provider.
+
+    They share the shape of a hosted tool, so a message blaming the Responses
+    API would send the reader looking in entirely the wrong place.
+    """
+    from agents import LocalShellTool
+
+    from agentor.engine.tools import resolve_tools
+
+    with pytest.raises(TypeError) as exc:
+        resolve_tools([LocalShellTool(executor=lambda *a, **k: "")])
+
+    message = str(exc.value)
+    assert "local_shell" in message
+    assert "Responses API" not in message
+
+
+def test_agentor_surfaces_the_unrunnable_tool_message():
     from agents import WebSearchTool
 
     from agentor import Agentor
 
-    with pytest.raises(TypeError, match="provider-hosted tool"):
+    with pytest.raises(TypeError, match="no callable to invoke"):
         Agentor(
             name="T",
             model="gpt-4o-mini",


### PR DESCRIPTION
Groundwork for Phase 5b. Does the unambiguous part; leaves the scope decision open.

## The problem

`WebSearchTool` and the other openai-agents hosted tools carry a `name` but nothing to invoke — the provider runs them server-side. On the native engine they fell into the generic `Unsupported tool type 'WebSearchTool'` branch, which says nothing about *why* a documented, exported tool (with its own example in `examples/tools/web_search.py`) stopped working, or what to do instead.

They now raise naming the tool, the reason, and the fix. Correct regardless of how hosted tools are ultimately handled.

## Two shortcuts probed and ruled out

I checked both before concluding a full adapter is the only real path.

**1. `web_search_options` on chat/completions** — the SDK accepts the parameter, so this looked like a cheap win. Probed against the live API:

| model | result |
|---|---|
| `gpt-4o-mini` | ❌ "Web search options not supported with this model" |
| `gpt-4o-mini-search-preview` | ✅ works, returns annotations |
| `gpt-5-mini` | ❌ "Unknown parameter: 'web_search_options'" |

`gpt-5-mini` is the model in our own web-search example. So this can't back `WebSearchTool` generally — it only works on `-search-preview` models.

**2. A Responses API adapter** — this does support hosted tools, and I spiked it. The cost is real: Responses uses a different item shape than chat/completions **in both directions** (assistant tool calls, tool results as `function_call_output`), plus its own streaming event set. Roughly **250–300 LOC and a second message format inside the engine** — exactly what the plan's "two adapters, not a hundred" rule was guarding against. The spike also showed a trivial hosted-search call burning **4,488 input tokens**.

## What I did not decide

Whether to build that adapter is a scope call, not an engineering detail, so I haven't built it speculatively. **Phase 5b cannot remove openai-agents until it's settled** — hosted tools are the only remaining thing that genuinely needs it.

The options, with honest cost:

| | cost | outcome |
|---|---|---|
| **A. Build `ResponsesModel`** | ~250–300 LOC + tests | Hosted tools work natively; also unlocks reasoning-item persistence for gpt-5. Second message format to maintain, OpenAI-only. |
| **B. Drop hosted tools** | ~0 | openai-agents goes entirely. Breaks `examples/tools/web_search.py` and anyone using `WebSearchTool`. |
| **C. Keep both engines** | ~0 | Hosted tools stay on `engine="agents"`; openai-agents stays a dependency forever. |

## Verification

- `270 passed, 2 skipped` (3 new — error path, `Agentor` surfacing it, and hosted tools still working on `engine="agents"`)
- Detection is by shape (a `name`, nothing to invoke), so it covers `FileSearchTool`, `CodeInterpreterTool`, `HostedMCPTool` and the rest, not just `WebSearchTool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a more actionable native-engine error for named tools that expose no callable implementation.
- Distinguishes provider-hosted and SDK-specific tools from generic unsupported tool types.
- Adds coverage for native-engine error propagation and continued hosted-tool support through the agents engine.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/engine/tools.py | Adds a targeted rejection path for named, non-callable tool objects after all supported invocation shapes have been checked. |
| tests/test_engine_review_fixes.py | Covers hosted and local SDK tool diagnostics, Agentor error propagation, and preservation of the agents-engine behavior. |

<sub>Reviews (2): Last reviewed commit: ["fix(engine): do not assert an execution ..."](https://github.com/celestoai/agentor/commit/97cc4afa73cd2899217279e9067b1ffce2985358) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48314733)</sub>

<!-- /greptile_comment -->