### PR TITLE
fix: address whole-line review of the v0.1.0 branch

### DIFF
--- a/docs/dev/MIGRATION_PLAN.md
+++ b/docs/dev/MIGRATION_PLAN.md
@@ -379,7 +379,7 @@ Native replacements for everything openai-agents used to supply:
 | `agents.function_tool` | `agentor.engine.tools.function_tool` |
 | `agents.ModelSettings` | `agentor.engine.settings.ModelSettings` (+ `extra` passthrough) |
 | `agents.FunctionTool` | `agentor.engine.tools.Tool` |
-| `agents.mcp.MCPServerStreamableHttp` | `agentor.mcp.MCPServer` |
+| `agents.mcp.MCPServerStreamableHttp` | `agentor.mcp.MCPServer` (old name still importable, deprecated) |
 | `LitellmModel` | `agentor.engine.models.LiteLLMModel` (old name still exported) |
 | openai-agents tracing | `agentor.engine.tracing`, via `setup_celesto_tracing` |
 

--- a/src/agentor/__init__.py
+++ b/src/agentor/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.1.0.dev1"
+__version__ = "0.1.0"
 
 __all__ = [
     "Agentor",

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -125,7 +125,7 @@ class Agentor:
         model_settings: Optional[ModelSettings] = None,
         skills: Optional[List[str]] = None,
         enable_tracing: bool = False,
-        max_turns: int = 10,
+        max_turns: int = 20,
         store: Any = None,
         base_url: Optional[str] = None,
         tracer: Any = None,
@@ -371,7 +371,7 @@ class Agentor:
         self,
         input: list[str] | str | list[AgentInputType],
         limit_concurrency: int = 10,
-        max_turns: int = 20,
+        max_turns: Optional[int] = None,
         fallback_models: Optional[List[str]] = None,
     ) -> List[str] | str:
         """
@@ -381,7 +381,8 @@ class Agentor:
         Args:
             input: A string prompt or a list of string prompts.
             limit_concurrency: The maximum number of concurrent tasks to run in case of a batch of prompts.
-            max_turns: The maximum number of turns to run the agent.
+            max_turns: Maximum turns for this call. Defaults to the value the
+                agent was constructed with.
             fallback_models: Optional list of fallback model names to try if the primary model
                 fails due to rate limits or API errors. Models are tried in order.
         """

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -135,13 +135,20 @@ class AgentLoop:
     # ------------------------------------------------------------ messages
 
     def _initial_messages(self, input: MessageInput) -> List[Dict[str, Any]]:
-        messages: List[Dict[str, Any]] = []
-        if self.instructions:
-            messages.append({"role": "system", "content": self.instructions})
         if isinstance(input, str):
+            messages: List[Dict[str, Any]] = []
+            if self.instructions:
+                messages.append({"role": "system", "content": self.instructions})
             messages.append({"role": "user", "content": input})
-        else:
-            messages.extend(input)
+            return messages
+
+        messages = list(input)
+        # A replayed run, or a caller supplying their own history, already
+        # carries its system message. Prepending another sends the instructions
+        # twice, which changes behaviour and some providers reject outright.
+        has_system = any(m.get("role") == "system" for m in messages)
+        if self.instructions and not has_system:
+            messages.insert(0, {"role": "system", "content": self.instructions})
         return messages
 
     @staticmethod
@@ -503,6 +510,12 @@ class AgentLoop:
                 result.final_output = event.text
                 result.usage = event.usage or Usage()
                 result.error = event.error
+
+        # documented as "feed this back in to continue the conversation", so it
+        # has to actually contain the conversation
+        from agentor.engine.store import replay_messages
+
+        result.messages = replay_messages(result.events)
 
         # Events stay plain text so the log remains JSON-serialisable; only the
         # returned result carries the parsed object.

--- a/src/agentor/engine/mcp.py
+++ b/src/agentor/engine/mcp.py
@@ -168,3 +168,37 @@ class MCPServer:
 
     async def __aexit__(self, *exc_info) -> None:
         await self.close()
+
+
+def MCPServerStreamableHttp(
+    name: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+    **_ignored: Any,
+) -> MCPServer:
+    """Compatibility shim for the constructor agentor exported before v0.1.0.
+
+    0.0.x code passes `params={"url": ..., "headers": ..., "timeout": ...}` and
+    options such as `cache_tools_list` that the native client does not need.
+    Failing on import would break those callers before they could read a
+    migration message, so the old call is translated instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "MCPServerStreamableHttp is deprecated; use "
+        "agentor.mcp.MCPServer(url=..., headers=..., timeout=...) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    params = params or {}
+    url = params.get("url")
+    if not url:
+        raise ValueError("MCPServerStreamableHttp requires params={'url': ...}.")
+
+    return MCPServer(
+        url=url,
+        headers=params.get("headers"),
+        timeout=float(params.get("timeout") or 30.0),
+        name=name or url,
+    )

--- a/src/agentor/mcp/__init__.py
+++ b/src/agentor/mcp/__init__.py
@@ -1,4 +1,4 @@
-from agentor.engine.mcp import MCPServer
+from agentor.engine.mcp import MCPServer, MCPServerStreamableHttp
 
 from .api_router import (
     Context,
@@ -19,4 +19,5 @@ __all__ = [
     "get_headers",
     "get_token",
     "MCPServer",
+    "MCPServerStreamableHttp",
 ]

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -858,3 +858,101 @@ def test_agentor_accepts_an_explicit_tracer():
     tracer = setup_celesto_tracing(endpoint="http://example/ingest", token="t")
     agent = Agentor(name="T", model="gpt-4o-mini", api_key="test", tracer=tracer)
     assert agent._loop.tracer is tracer
+
+
+# ============================================ whole-line review
+
+
+def test_version_is_a_stable_release():
+    """pip skips prereleases by default, so 0.1.0.devN would strand upgraders."""
+    import agentor
+
+    assert "dev" not in agentor.__version__
+    assert "rc" not in agentor.__version__
+
+
+def test_the_previous_mcp_import_still_works():
+    """0.0.22 code must not fail at import before it can read a migration note."""
+    import warnings
+
+    from agentor.mcp import MCPServer, MCPServerStreamableHttp
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        server = MCPServerStreamableHttp(
+            name="x",
+            params={"url": "http://e/mcp", "headers": {"A": "b"}, "timeout": 10},
+            cache_tools_list=True,
+            max_retry_attempts=3,
+        )
+
+    assert isinstance(server, MCPServer)
+    assert server.url == "http://e/mcp"
+    assert server.headers == {"A": "b"}
+    assert any(w.category is DeprecationWarning for w in caught)
+
+
+def test_the_old_mcp_shim_rejects_a_missing_url():
+    from agentor.mcp import MCPServerStreamableHttp
+
+    with pytest.raises(ValueError, match="requires params"):
+        MCPServerStreamableHttp(name="x", params={})
+
+
+@pytest.mark.asyncio
+async def test_run_result_carries_the_conversation():
+    """RunResult.messages is documented as resumable context; it must contain it."""
+    model = FakeModel(calls(("weather", '{"city": "Oslo"}')), text("sunny"))
+    result = await AgentLoop(model=model, tools=[weather], instructions="sys").arun(
+        "weather?"
+    )
+
+    roles = [m["role"] for m in result.messages]
+    assert roles == ["system", "user", "assistant", "tool", "assistant"]
+    assert result.messages[-1]["content"] == "sunny"
+
+
+@pytest.mark.asyncio
+async def test_resume_does_not_duplicate_the_system_prompt():
+    """replay already returns the system message; prepending sends it twice."""
+    store = MemoryStore()
+    first = await AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "X"}'))),
+        tools=[weather],
+        store=store,
+        max_turns=1,
+        instructions="SYSTEM PROMPT",
+    ).arun("go")
+
+    model = FakeModel(text("done"))
+    await AgentLoop(
+        model=model, tools=[weather], store=store, instructions="SYSTEM PROMPT"
+    ).aresume(first.run_id)
+
+    roles = [m["role"] for m in model.calls[0]["messages"]]
+    assert roles.count("system") == 1, f"duplicated system prompt: {roles}"
+
+
+@pytest.mark.asyncio
+async def test_a_supplied_system_message_is_not_duplicated():
+    model = FakeModel(text("ok"))
+    await AgentLoop(model=model, instructions="AGENT").arun(
+        [{"role": "system", "content": "CALLER"}, {"role": "user", "content": "hi"}]
+    )
+
+    messages = model.calls[0]["messages"]
+    assert [m["role"] for m in messages] == ["system", "user"]
+    assert messages[0]["content"] == "CALLER", "the caller's system message wins"
+
+
+@pytest.mark.asyncio
+async def test_arun_respects_the_constructor_turn_budget():
+    """run() honoured it while arun() silently overrode it with its default."""
+    from agentor import Agentor
+
+    model = FakeModel(*[calls(("weather", '{"city": "X"}')) for _ in range(10)])
+    agent = Agentor(name="T", model=model, tools=[weather], api_key="test", max_turns=3)
+    result = await agent.arun("go")
+
+    assert result.status == "max_turns"
+    assert len(model.calls) == 3


### PR DESCRIPTION
Ran `codex review` over **`main...agentor-v0.1.0`** — the complete v0.1.0 change as one unit (54 files, +5148/−2004).

Every prior review looked at a single PR against its own base. **None of these five were visible that way** — they only appear once the pieces sit together. Two are release blockers.

## P1 — would have shipped broken

**The version was `0.1.0.dev1`.** pip excludes prereleases when a stable release exists, so `pip install --upgrade agentor` would have left **every 0.0.x user exactly where they were**. A silent no-op release. Now `0.1.0`; a test asserts no `dev`/`rc` in the version.

**`from agentor.mcp import MCPServerStreamableHttp` raised `ImportError`.** 0.0.22 code died at import, before it could read any migration message — and it contradicted `MIGRATION_PLAN.md:308`, which claims such calls are adapted. The old constructor now translates to `MCPServer` with a `DeprecationWarning`, accepting the `params={"url":..., "headers":..., "timeout":...}` shape and ignoring options the native client doesn't need.

## P2 — three real defects

**Resume sent the system prompt twice.** `replay_messages()` already returns the system message, and `_initial_messages()` prepended another. Verified: `['system', 'system', 'user', 'assistant', 'tool']`. Changes behaviour and some providers reject it outright. A caller supplying their *own* system message hit the same bug — and now theirs wins over the agent's instructions.

**`RunResult.messages` was always `[]`** despite being documented as "the full message list, suitable for feeding back in to continue the conversation." Anyone doing that lost all prior context. Now populated from the run's own events, reusing the already-tested `replay_messages`.

**`arun()` forced `max_turns=20`** regardless of `Agentor(max_turns=N)`, while `run()` honoured it — so the sync and async paths silently disagreed. `arun` now defers to the constructor. I moved the old `arun` default onto the constructor, so **async runs keep the same budget as before** and sync runs become *more* permissive rather than less — the safer direction for a breaking release.

## Verification

- `260 passed, 2 skipped` (7 new, one per finding)
- Live re-run: engine 22/22, MCP 9/9, **OpenRouter 12/12**, cross-process resume recovers
- `uv build` → `agentor-0.1.0.tar.gz` / `.whl`, stable version confirmed

## Note

This is why the whole-line pass was worth running. Per-PR review is structurally blind to contract drift across commits — the `max_turns` disagreement and the empty `RunResult.messages` were each introduced in one PR and only became wrong in another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses release and compatibility defects in the v0.1.0 branch.
- Marks the package as stable version 0.1.0.
- Adds a deprecated adapter for the former MCP streamable HTTP constructor.
- Preserves caller or replayed system messages without duplicating configured instructions.
- Populates ordinary run results with replayable messages and aligns async turn limits with constructor configuration.
- Adds regression tests and updates the migration plan.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until resumed runs return the complete conversation through `RunResult.messages`.

The new message-population behavior works for ordinary runs, but both resume branches still violate the same public contract by returning either an empty or continuation-only message list.

**Files Needing Attention:** src/agentor/engine/loop.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentor/engine/loop.py | Fixes duplicate system prompts and populates normal run messages, but resumed results still return empty or incomplete message histories. |
| src/agentor/core/agent.py | Moves the default turn budget to construction and lets async calls defer to the configured value. |
| src/agentor/engine/mcp.py | Adds a deprecated compatibility constructor that maps the legacy URL, headers, and timeout shape to the native MCP server. |
| src/agentor/mcp/__init__.py | Re-exports the legacy MCP constructor name. |
| src/agentor/__init__.py | Changes the package version from a development prerelease to stable 0.1.0. |
| tests/test_engine_review_fixes.py | Adds regression coverage for the five described fixes but does not verify `messages` returned by either resume branch. |
| docs/dev/MIGRATION_PLAN.md | Documents continued deprecated availability of the old MCP constructor name. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[aresume run_id] --> B{Persisted run complete?}
  B -->|Yes| C[Construct RunResult from stored events]
  C --> D[messages remains empty]
  B -->|No| E[Replay prior messages]
  E --> F[arun continuation]
  F --> G[Derive messages from continuation events]
  G --> H[Prepend stored events to result.events]
  H --> I[messages remains continuation-only]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentor/engine/loop.py`, line 594 ([link](https://github.com/celestoai/agentor/blob/517c8b824e7f7d0d7604e6075317d57c77794497/src/agentor/engine/loop.py#L594)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Resumed message history remains incomplete**

   When a persisted run is resumed, the completed branch leaves `RunResult.messages` empty, while the unfinished branch derives it before adding the earlier events. Callers that feed `messages` back into another run therefore lose either the entire conversation or everything before the resume point.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: address whole-line review of the v0..."](https://github.com/celestoai/agentor/commit/517c8b824e7f7d0d7604e6075317d57c77794497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48334839)</sub>

<!-- /greptile_comment -->