### PR TITLE
feat!: tracing is opt-in, and controllable per run

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,25 @@ https://api.celesto.ai/deploy/apps/<app-name>
 
 ## Tracing
 
-Agentor sends traces to Celesto automatically when `CELESTO_API_KEY` is set, and prints a
-notice when it does. Turn it off globally with `CELESTO_DISABLE_AUTO_TRACING=True`, or
-decide per run:
+Tracing is **off unless you ask for it**. A trace carries prompts, tool arguments and tool
+results, so nothing leaves your process by default.
+
+Turn it on for an agent:
 
 ```python
-agent.run("public question")                    # traced, if tracing is on
-agent.run("contains customer data", tracing=False)   # this run sends nothing
-agent.run("debug this", tracing=True)           # trace just this one
+agent = Agentor(name="Assistant", enable_tracing=True)   # needs CELESTO_API_KEY
 ```
 
-`tracing=` is accepted by `run`, `arun`, `chat` and `stream_chat`. Traces carry prompts,
-tool arguments and tool results, so use `tracing=False` for inputs that must not leave
-the process.
+Or decide per run:
+
+```python
+agent.run("public question")
+agent.run("contains customer data", tracing=False)  # this run sends nothing
+agent.run("debug this", tracing=True)               # trace just this one
+```
+
+`tracing=` is accepted by `run`, `arun`, `chat` and `stream_chat`. View traces at
+[celesto.ai/observe](https://celesto.ai/observe).
 
 ## Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Once deployed, your agent will be accessible via a REST endpoint, for example:
 https://api.celesto.ai/deploy/apps/<app-name>
 ```
 
+## Tracing
+
+Agentor sends traces to Celesto automatically when `CELESTO_API_KEY` is set, and prints a
+notice when it does. Turn it off globally with `CELESTO_DISABLE_AUTO_TRACING=True`, or
+decide per run:
+
+```python
+agent.run("public question")                    # traced, if tracing is on
+agent.run("contains customer data", tracing=False)   # this run sends nothing
+agent.run("debug this", tracing=True)           # trace just this one
+```
+
+`tracing=` is accepted by `run`, `arun`, `chat` and `stream_chat`. Traces carry prompts,
+tool arguments and tool results, so use `tracing=False` for inputs that must not leave
+the process.
+
 ## Agent Skills
 
 Skills are folders of instructions, scripts, and resources that Claude loads dynamically to improve performance on specialized tasks.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from agentor import Agentor
+
+agent = Agentor.from_md("AGENTS.md")
+result = agent.run("Weather in Paris?")
+print(result)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,0 @@
-from agentor import Agentor
-
-agent = Agentor.from_md("AGENTS.md")
-result = agent.run("Weather in Paris?")
-print(result)

--- a/src/agentor/config.py
+++ b/src/agentor/config.py
@@ -11,9 +11,6 @@ class CelestoConfig(BaseSettings):
     api_key: Optional[SecretStr] = Field(
         alias="CELESTO_API_KEY", default=None
     )  # default to Celesto's API key
-    disable_auto_tracing: bool = Field(
-        alias="CELESTO_DISABLE_AUTO_TRACING", default=False
-    )
 
 
 celesto_config = CelestoConfig()

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -210,24 +210,29 @@ class Agentor:
             **params,
         )
 
-    def _resolve_tracing(self, tracing: Optional[bool]) -> Optional[bool]:
+    def _resolve_tracing(self, tracing: Any) -> Any:
         """Turn a per-run tracing flag into something the loop can act on.
 
-        `tracing=True` on an agent with no tracer is a reasonable request,
-        not an error: build one from CELESTO_API_KEY so a single run can be
+        `tracing=True` on an agent with no tracer is a reasonable request, not
+        an error: one is built from CELESTO_API_KEY so a single run can be
         traced without turning tracing on for the whole agent.
+
+        The tracer is returned for the loop to use for that run, never stored
+        on the agent. Storing it would mean opting one run in quietly enrolled
+        every later run too, which is the exact failure this API exists to
+        prevent.
         """
-        if tracing and self._loop.tracer is None:
-            if not celesto_config.api_key:
-                raise ValueError(
-                    "tracing=True requires a Celesto API key. Set "
-                    "CELESTO_API_KEY, or pass tracer= when building the agent."
-                )
-            self._loop.tracer = setup_celesto_tracing(
-                endpoint=f"{celesto_config.base_url}/traces/ingest",
-                token=celesto_config.api_key.get_secret_value(),
+        if tracing is not True or self._loop.tracer is not None:
+            return tracing
+        if not celesto_config.api_key:
+            raise ValueError(
+                "tracing=True requires a Celesto API key. Set CELESTO_API_KEY, "
+                "or pass tracer= when building the agent."
             )
-        return tracing
+        return setup_celesto_tracing(
+            endpoint=f"{celesto_config.base_url}/traces/ingest",
+            token=celesto_config.api_key.get_secret_value(),
+        )
 
     def _native_tracer(self, enable_tracing: bool):
         """Build a tracer, but only when tracing was asked for.
@@ -376,7 +381,7 @@ class Agentor:
             model_settings=resolved_model_settings,
         )
 
-    def run(self, input: str, tracing: Optional[bool] = None) -> Any:
+    def run(self, input: str, tracing: Any = None) -> Any:
         """Run the agent.
 
         Args:
@@ -393,7 +398,7 @@ class Agentor:
         limit_concurrency: int = 10,
         max_turns: Optional[int] = None,
         fallback_models: Optional[List[str]] = None,
-        tracing: Optional[bool] = None,
+        tracing: Any = None,
     ) -> List[str] | str:
         """
         Run the agent with an input prompt or a batch of prompts.

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -213,9 +213,9 @@ class Agentor:
     def _resolve_tracing(self, tracing: Optional[bool]) -> Optional[bool]:
         """Turn a per-run tracing flag into something the loop can act on.
 
-        `tracing=True` on an agent with no tracer is a reasonable request, not
-        an error: build one from CELESTO_API_KEY so a single run can be traced
-        even when auto-tracing is off.
+        `tracing=True` on an agent with no tracer is a reasonable request,
+        not an error: build one from CELESTO_API_KEY so a single run can be
+        traced without turning tracing on for the whole agent.
         """
         if tracing and self._loop.tracer is None:
             if not celesto_config.api_key:
@@ -230,26 +230,19 @@ class Agentor:
         return tracing
 
     def _native_tracer(self, enable_tracing: bool):
-        """Build a tracer from CELESTO_API_KEY, if tracing is on."""
-        if not enable_tracing and (
-            celesto_config.api_key is None or celesto_config.disable_auto_tracing
-        ):
+        """Build a tracer, but only when tracing was asked for.
+
+        Tracing is opt-in. A trace carries prompts, tool arguments and tool
+        results, so merely having a Celesto API key configured - which the SDK
+        and the MCP hub also use - is not consent to ship run contents to a
+        remote endpoint.
+        """
+        if not enable_tracing:
             return None
         if not celesto_config.api_key:
-            if enable_tracing:
-                raise ValueError(
-                    "Celesto API key is required to enable tracing. "
-                    "Find it at https://celesto.ai/dashboard and set CELESTO_API_KEY."
-                )
-            return None
-
-        if not enable_tracing:
-            # Auto-enabled from CELESTO_API_KEY. Say so: quietly shipping run
-            # contents to a remote endpoint should never be a surprise.
-            print(
-                "auto enabled LLM monitoring and tracing. "
-                "View traces: https://celesto.ai/observe"
-                "\nTo disable, set CELESTO_DISABLE_AUTO_TRACING=True."
+            raise ValueError(
+                "Celesto API key is required to enable tracing. "
+                "Find it at https://celesto.ai/dashboard and set CELESTO_API_KEY."
             )
 
         try:
@@ -390,7 +383,7 @@ class Agentor:
             input: The prompt.
             tracing: Override tracing for this run alone. None keeps whatever
                 the agent was configured with, False sends nothing for this
-                run, True traces it even if auto-tracing is off.
+                run, True traces it even when the agent has tracing off.
         """
         return self._loop.run(input, tracing=self._resolve_tracing(tracing))
 
@@ -414,8 +407,8 @@ class Agentor:
             fallback_models: Optional list of fallback model names to try if the primary model
                 fails due to rate limits or API errors. Models are tried in order.
             tracing: Override tracing for this call alone. None keeps the
-                agent's configuration, False sends nothing, True traces even
-                when auto-tracing is off.
+                agent's configuration, False sends nothing, True traces
+                even when the agent has tracing off.
         """
         tracing = self._resolve_tracing(tracing)
         if isinstance(input, list):

--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -210,6 +210,25 @@ class Agentor:
             **params,
         )
 
+    def _resolve_tracing(self, tracing: Optional[bool]) -> Optional[bool]:
+        """Turn a per-run tracing flag into something the loop can act on.
+
+        `tracing=True` on an agent with no tracer is a reasonable request, not
+        an error: build one from CELESTO_API_KEY so a single run can be traced
+        even when auto-tracing is off.
+        """
+        if tracing and self._loop.tracer is None:
+            if not celesto_config.api_key:
+                raise ValueError(
+                    "tracing=True requires a Celesto API key. Set "
+                    "CELESTO_API_KEY, or pass tracer= when building the agent."
+                )
+            self._loop.tracer = setup_celesto_tracing(
+                endpoint=f"{celesto_config.base_url}/traces/ingest",
+                token=celesto_config.api_key.get_secret_value(),
+            )
+        return tracing
+
     def _native_tracer(self, enable_tracing: bool):
         """Build a tracer from CELESTO_API_KEY, if tracing is on."""
         if not enable_tracing and (
@@ -364,8 +383,16 @@ class Agentor:
             model_settings=resolved_model_settings,
         )
 
-    def run(self, input: str) -> Any:
-        return self._loop.run(input)
+    def run(self, input: str, tracing: Optional[bool] = None) -> Any:
+        """Run the agent.
+
+        Args:
+            input: The prompt.
+            tracing: Override tracing for this run alone. None keeps whatever
+                the agent was configured with, False sends nothing for this
+                run, True traces it even if auto-tracing is off.
+        """
+        return self._loop.run(input, tracing=self._resolve_tracing(tracing))
 
     async def arun(
         self,
@@ -373,6 +400,7 @@ class Agentor:
         limit_concurrency: int = 10,
         max_turns: Optional[int] = None,
         fallback_models: Optional[List[str]] = None,
+        tracing: Optional[bool] = None,
     ) -> List[str] | str:
         """
         Run the agent with an input prompt or a batch of prompts.
@@ -385,10 +413,16 @@ class Agentor:
                 agent was constructed with.
             fallback_models: Optional list of fallback model names to try if the primary model
                 fails due to rate limits or API errors. Models are tried in order.
+            tracing: Override tracing for this call alone. None keeps the
+                agent's configuration, False sends nothing, True traces even
+                when auto-tracing is off.
         """
+        tracing = self._resolve_tracing(tracing)
         if isinstance(input, list):
             if isinstance(input[0], dict):
-                return await self._loop.arun(input, max_turns=max_turns)
+                return await self._loop.arun(
+                    input, max_turns=max_turns, tracing=tracing
+                )
 
             futures = []
             if limit_concurrency > 0:
@@ -397,7 +431,7 @@ class Agentor:
                 async def _run_task(task: str) -> str:
                     async with semaphore:
                         return await self._run_with_fallback(
-                            task, max_turns, fallback_models
+                            task, max_turns, fallback_models, tracing
                         )
 
                 futures = [_run_task(task) for task in input]
@@ -405,19 +439,24 @@ class Agentor:
             else:
                 return await asyncio.gather(
                     *[
-                        self._run_with_fallback(task, max_turns, fallback_models)
+                        self._run_with_fallback(
+                            task, max_turns, fallback_models, tracing
+                        )
                         for task in input
                     ],
                     return_exceptions=True,
                 )
         else:
-            return await self._run_with_fallback(input, max_turns, fallback_models)
+            return await self._run_with_fallback(
+                input, max_turns, fallback_models, tracing
+            )
 
     async def _run_with_fallback(
         self,
         task: str,
         max_turns: Optional[int] = None,
         fallback_models: Optional[List[str]] = None,
+        tracing: Optional[bool] = None,
     ):
         """Run a task, falling back to other models on rate limits.
 
@@ -425,7 +464,7 @@ class Agentor:
         because the model is not baked into the agent here.
         """
         try:
-            return await self._loop.arun(task, max_turns=max_turns)
+            return await self._loop.arun(task, max_turns=max_turns, tracing=tracing)
         except Exception as e:
             if not _is_retryable(e) or not fallback_models:
                 raise
@@ -441,7 +480,7 @@ class Agentor:
                         fallback_model,
                         api_key=self.api_key,
                         **getattr(self._loop.model, "params", {}),
-                    ).arun(task, max_turns=max_turns)
+                    ).arun(task, max_turns=max_turns, tracing=tracing)
                 except Exception as fallback_error:
                     if not _is_retryable(fallback_error):
                         raise
@@ -471,23 +510,25 @@ class Agentor:
         input: str,
         stream: bool = False,
         serialize: bool = True,
+        tracing: Optional[bool] = None,
     ):
         if stream:
-            return self.stream_chat(input, serialize=serialize)
-        return await self._loop.arun(input)
+            return self.stream_chat(input, serialize=serialize, tracing=tracing)
+        return await self._loop.arun(input, tracing=self._resolve_tracing(tracing))
 
     async def stream_chat(
         self,
         input: str,
         serialize: bool = True,
+        tracing: Optional[bool] = None,
     ) -> AsyncIterator[Union[str, AgentOutput]]:
-        async for agent_output in self._native_stream()(input):
+        async for agent_output in self._native_stream(tracing)(input):
             if serialize:
                 yield agent_output.serialize(dump_json=True)
             else:
                 yield agent_output
 
-    def _native_stream(self):
+    def _native_stream(self, tracing: Optional[bool] = None):
         """Project engine events onto AgentOutput.
 
         Keeps `serve()`, the /chat endpoint and the A2A handler working against
@@ -502,7 +543,9 @@ class Agentor:
                 from agentor.engine.store import new_run_id
 
                 run_id = new_run_id()
-            async for event in self._loop.astream(input, run_id=run_id):
+            async for event in self._loop.astream(
+                input, run_id=run_id, tracing=self._resolve_tracing(tracing)
+            ):
                 if event.type == "message":
                     yield AgentOutput(type="run_item_stream_event", message=event.text)
                 elif event.type == "tool_call":

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -121,18 +121,28 @@ class AgentLoop:
         )
         self.tools: Dict[str, Tool] = {t.name: t for t in resolve_tools(tools)}
 
-    def _tracer_for_run(self, tracing: Optional[bool]) -> Any:
-        """Resolve which tracer, if any, a single run should use."""
+    def _tracer_for_run(self, tracing: Any) -> Any:
+        """Resolve which tracer, if any, a single run should use.
+
+        `tracing` may also be a tracer object, which is used for that run only
+        and never stored: a caller opting one run in must not silently leave
+        the agent tracing every run after it.
+
+        Identity comparisons rather than truthiness, since a tracer object is
+        itself truthy.
+        """
         if tracing is None:
             return self.tracer
-        if not tracing:
+        if tracing is False:
             return None
-        if self.tracer is None:
-            raise ValueError(
-                "tracing=True but no tracer is configured. Pass tracer= when "
-                "building the agent, or set CELESTO_API_KEY."
-            )
-        return self.tracer
+        if tracing is True:
+            if self.tracer is None:
+                raise ValueError(
+                    "tracing=True but no tracer is configured. Pass tracer= "
+                    "when building the agent, or set CELESTO_API_KEY."
+                )
+            return self.tracer
+        return tracing
 
     def with_model(self, model: Any, **kwargs: Any) -> "AgentLoop":
         """Copy this loop with a different model.
@@ -303,7 +313,7 @@ class AgentLoop:
         stream_text: bool = False,
         run_id: Optional[str] = None,
         max_turns: Optional[int] = None,
-        tracing: Optional[bool] = None,
+        tracing: Any = None,
     ) -> AsyncIterator[Event]:
         """Run the agent, emitting every event, tracing and persisting it.
 
@@ -515,7 +525,7 @@ class AgentLoop:
         input: MessageInput,
         run_id: Optional[str] = None,
         max_turns: Optional[int] = None,
-        tracing: Optional[bool] = None,
+        tracing: Any = None,
     ) -> RunResult:
         if self.store is not None and run_id is None:
             from agentor.engine.store import new_run_id
@@ -561,7 +571,7 @@ class AgentLoop:
         input: MessageInput,
         run_id: Optional[str] = None,
         max_turns: Optional[int] = None,
-        tracing: Optional[bool] = None,
+        tracing: Any = None,
     ) -> RunResult:
         return self._sync(
             self.arun(input, run_id=run_id, max_turns=max_turns, tracing=tracing)

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -121,6 +121,19 @@ class AgentLoop:
         )
         self.tools: Dict[str, Tool] = {t.name: t for t in resolve_tools(tools)}
 
+    def _tracer_for_run(self, tracing: Optional[bool]) -> Any:
+        """Resolve which tracer, if any, a single run should use."""
+        if tracing is None:
+            return self.tracer
+        if not tracing:
+            return None
+        if self.tracer is None:
+            raise ValueError(
+                "tracing=True but no tracer is configured. Pass tracer= when "
+                "building the agent, or set CELESTO_API_KEY."
+            )
+        return self.tracer
+
     def with_model(self, model: Any, **kwargs: Any) -> "AgentLoop":
         """Copy this loop with a different model.
 
@@ -290,13 +303,19 @@ class AgentLoop:
         stream_text: bool = False,
         run_id: Optional[str] = None,
         max_turns: Optional[int] = None,
+        tracing: Optional[bool] = None,
     ) -> AsyncIterator[Event]:
         """Run the agent, emitting every event, tracing and persisting it.
+
+        `tracing` overrides the configured tracer for this run alone: None uses
+        it, False turns it off, True requires one. Useful when a particular
+        input must not leave the process.
 
         Note that a consumer which abandons this generator early stops the
         trace from being exported; `arun` always drains it.
         """
-        collector = self.tracer.collector(self.name) if self.tracer else None
+        tracer = self._tracer_for_run(tracing)
+        collector = tracer.collector(self.name) if tracer else None
         run_started = time.time()
 
         async def record(event: Event) -> None:
@@ -353,7 +372,7 @@ class AgentLoop:
         finally:
             if collector is not None:
                 try:
-                    await asyncio.to_thread(self.tracer.export, collector)
+                    await asyncio.to_thread(tracer.export, collector)
                 except Exception as e:
                     logger.warning("Trace export failed: %s", e)
 
@@ -496,6 +515,7 @@ class AgentLoop:
         input: MessageInput,
         run_id: Optional[str] = None,
         max_turns: Optional[int] = None,
+        tracing: Optional[bool] = None,
     ) -> RunResult:
         if self.store is not None and run_id is None:
             from agentor.engine.store import new_run_id
@@ -503,7 +523,9 @@ class AgentLoop:
             run_id = new_run_id()
 
         result = RunResult(run_id=run_id)
-        async for event in self.astream(input, run_id=run_id, max_turns=max_turns):
+        async for event in self.astream(
+            input, run_id=run_id, max_turns=max_turns, tracing=tracing
+        ):
             result.events.append(event)
             if event.type == "run_end":
                 result.status = event.status or "completed"
@@ -539,8 +561,11 @@ class AgentLoop:
         input: MessageInput,
         run_id: Optional[str] = None,
         max_turns: Optional[int] = None,
+        tracing: Optional[bool] = None,
     ) -> RunResult:
-        return self._sync(self.arun(input, run_id=run_id, max_turns=max_turns))
+        return self._sync(
+            self.arun(input, run_id=run_id, max_turns=max_turns, tracing=tracing)
+        )
 
     async def aresume(self, run_id: str) -> RunResult:
         """Continue a persisted run from where it stopped.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -374,7 +374,7 @@ def test_agentor_with_enable_tracing_true(mock_setup_tracing):
         config = CelestoConfig()
 
         with patch("agentor.core.agent.celesto_config", config):
-            agent = Agentor(
+            Agentor(
                 name="TracingAgent",
                 model="gpt-5-mini",
                 api_key="test",
@@ -400,7 +400,7 @@ def test_agentor_with_enable_tracing_missing_api_key(mock_setup_tracing):
 
         with patch("agentor.core.agent.celesto_config", config):
             with pytest.raises(ValueError, match="Celesto API key is required"):
-                agent = Agentor(
+                Agentor(
                     name="TracingAgent",
                     model="gpt-5-mini",
                     api_key="test",
@@ -412,107 +412,54 @@ def test_agentor_with_enable_tracing_missing_api_key(mock_setup_tracing):
 
 
 @patch("agentor.core.agent.setup_celesto_tracing")
-def test_agentor_auto_tracing_enabled(mock_setup_tracing, capsys):
-    """Test that auto-tracing is enabled when API key is present and not disabled."""
-    with patch.dict(
-        "os.environ",
-        {
-            "CELESTO_API_KEY": "test-api-key-456",
-            "CELESTO_DISABLE_AUTO_TRACING": "false",
-        },
-        clear=False,
-    ):
+def test_a_celesto_key_alone_does_not_enable_tracing(mock_setup_tracing, capsys):
+    """Tracing is opt-in.
+
+    A Celesto API key is also used by the SDK and the MCP hub, so its presence
+    is not consent to ship prompts and tool results to a remote endpoint.
+    """
+    with patch.dict("os.environ", {"CELESTO_API_KEY": "test-api-key-456"}, clear=False):
         from agentor.config import CelestoConfig
 
-        config = CelestoConfig()
+        with patch("agentor.core.agent.celesto_config", CelestoConfig()):
+            agent = Agentor(name="A", model="gpt-5-mini", api_key="test")
 
-        with patch("agentor.core.agent.celesto_config", config):
-            agent = Agentor(
-                name="AutoTracingAgent",
-                model="gpt-5-mini",
-                api_key="test",
-                enable_tracing=False,  # Explicit False, but auto-tracing should still work
-            )
-
-            # Verify setup_celesto_tracing was called
-            mock_setup_tracing.assert_called_once()
-
-            # Verify the message was printed
-            captured = capsys.readouterr()
-            assert "auto enabled LLM monitoring and tracing" in captured.out
-            assert "https://celesto.ai/observe" in captured.out
+    mock_setup_tracing.assert_not_called()
+    assert agent._loop.tracer is None
+    assert capsys.readouterr().out == "", "opt-in tracing should say nothing"
 
 
 @patch("agentor.core.agent.setup_celesto_tracing")
-def test_agentor_auto_tracing_disabled(mock_setup_tracing):
-    """Test that auto-tracing is disabled when CELESTO_DISABLE_AUTO_TRACING=True."""
-    with patch.dict(
-        "os.environ",
-        {"CELESTO_API_KEY": "test-api-key-789", "CELESTO_DISABLE_AUTO_TRACING": "true"},
-        clear=False,
-    ):
+def test_enable_tracing_sets_it_up(mock_setup_tracing):
+    with patch.dict("os.environ", {"CELESTO_API_KEY": "test-api-key-456"}, clear=False):
         from agentor.config import CelestoConfig
 
-        config = CelestoConfig()
+        with patch("agentor.core.agent.celesto_config", CelestoConfig()):
+            Agentor(name="A", model="gpt-5-mini", api_key="test", enable_tracing=True)
 
-        with patch("agentor.core.agent.celesto_config", config):
-            agent = Agentor(
-                name="NoAutoTracingAgent",
-                model="gpt-5-mini",
-                api_key="test",
-                enable_tracing=False,
-            )
-
-            # Tracing should not be set up
-            mock_setup_tracing.assert_not_called()
+    mock_setup_tracing.assert_called_once()
+    kwargs = mock_setup_tracing.call_args[1]
+    assert "/traces/ingest" in kwargs["endpoint"]
+    assert kwargs["token"] == "test-api-key-456"
 
 
 @patch("agentor.core.agent.setup_celesto_tracing")
-def test_agentor_auto_tracing_no_api_key(mock_setup_tracing):
-    """Test that auto-tracing is not enabled when API key is not present."""
-    with patch.dict("os.environ", clear=True):
-        from agentor.config import CelestoConfig
-
-        config = CelestoConfig()
-
-        with patch("agentor.core.agent.celesto_config", config):
-            agent = Agentor(
-                name="NoApiKeyAgent",
-                model="gpt-5-mini",
-                api_key="test",
-                enable_tracing=False,
-            )
-
-            # Tracing should not be set up
-            mock_setup_tracing.assert_not_called()
-
-
-@patch("agentor.core.agent.setup_celesto_tracing")
-def test_agentor_auto_tracing_error_handling(mock_setup_tracing, caplog):
-    """Test that auto-tracing errors are handled gracefully."""
+def test_tracing_setup_failure_does_not_break_construction(mock_setup_tracing, caplog):
     mock_setup_tracing.side_effect = Exception("Tracing setup failed")
 
     with patch.dict(
-        "os.environ",
-        {"CELESTO_API_KEY": "test-api-key-error"},
-        clear=False,
+        "os.environ", {"CELESTO_API_KEY": "test-api-key-error"}, clear=False
     ):
         from agentor.config import CelestoConfig
 
-        config = CelestoConfig()
-
-        with patch("agentor.core.agent.celesto_config", config):
+        with patch("agentor.core.agent.celesto_config", CelestoConfig()):
             with caplog.at_level(logging.WARNING):
-                # Should not raise exception
                 agent = Agentor(
-                    name="ErrorHandlingAgent",
+                    name="A",
                     model="gpt-5-mini",
                     api_key="test",
-                    enable_tracing=False,
+                    enable_tracing=True,
                 )
 
-                # Should log warning
-                assert any(
-                    "Failed to setup Celesto tracing" in message
-                    for message in caplog.messages
-                )
+    assert agent._loop.tracer is None, "the agent is still usable"
+    assert any("Failed to setup Celesto tracing" in m for m in caplog.messages)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,6 @@
 import os
 from unittest.mock import patch
 
-import pytest
-
 from agentor.config import CelestoConfig, celesto_config
 
 
@@ -17,7 +15,6 @@ class TestCelestoConfig:
 
         assert config.base_url == "https://api.celesto.ai/v1"
         assert config.api_key is None
-        assert config.disable_auto_tracing is False
 
     def test_custom_base_url(self):
         """Test CelestoConfig with custom base_url."""
@@ -34,35 +31,17 @@ class TestCelestoConfig:
             assert config.api_key is not None
             assert config.api_key.get_secret_value() == "test-key-123"
 
-    def test_disable_auto_tracing_true(self):
-        """Test CelestoConfig with disable_auto_tracing set to True."""
-        with patch.dict(
-            os.environ, {"CELESTO_DISABLE_AUTO_TRACING": "true"}, clear=False
-        ):
-            config = CelestoConfig()
-            assert config.disable_auto_tracing is True
-
-    def test_disable_auto_tracing_false(self):
-        """Test CelestoConfig with disable_auto_tracing set to False."""
-        with patch.dict(
-            os.environ, {"CELESTO_DISABLE_AUTO_TRACING": "false"}, clear=False
-        ):
-            config = CelestoConfig()
-            assert config.disable_auto_tracing is False
-
     def test_all_custom_values(self):
         """Test CelestoConfig with all custom values."""
         env_vars = {
             "CELESTO_BASE_URL": "https://custom.api.com/v3",
             "CELESTO_API_KEY": "custom-key-456",
-            "CELESTO_DISABLE_AUTO_TRACING": "True",
         }
 
         with patch.dict(os.environ, env_vars, clear=False):
             config = CelestoConfig()
             assert config.base_url == "https://custom.api.com/v3"
             assert config.api_key.get_secret_value() == "custom-key-456"
-            assert config.disable_auto_tracing is True
 
     def test_api_key_is_secret(self):
         """Test that api_key is properly stored as SecretStr."""
@@ -95,36 +74,3 @@ class TestCelestoConfigFieldAliases:
         with patch.dict(os.environ, {"CELESTO_API_KEY": "test-api-key"}, clear=False):
             config = CelestoConfig()
             assert config.api_key.get_secret_value() == "test-api-key"
-
-    def test_disable_auto_tracing_alias(self):
-        """Test CELESTO_DISABLE_AUTO_TRACING environment variable alias."""
-        with patch.dict(os.environ, {"CELESTO_DISABLE_AUTO_TRACING": "1"}, clear=False):
-            config = CelestoConfig()
-            assert config.disable_auto_tracing is True
-
-
-class TestCelestoConfigBooleanParsing:
-    """Test suite for CelestoConfig boolean value parsing."""
-
-    @pytest.mark.parametrize(
-        "env_value,expected",
-        [
-            ("true", True),
-            ("True", True),
-            ("TRUE", True),
-            ("1", True),
-            ("yes", True),
-            ("false", False),
-            ("False", False),
-            ("FALSE", False),
-            ("0", False),
-            ("no", False),
-        ],
-    )
-    def test_disable_auto_tracing_boolean_values(self, env_value, expected):
-        """Test various boolean representations for disable_auto_tracing."""
-        with patch.dict(
-            os.environ, {"CELESTO_DISABLE_AUTO_TRACING": env_value}, clear=False
-        ):
-            config = CelestoConfig()
-            assert config.disable_auto_tracing is expected

--- a/tests/test_engine_tracing.py
+++ b/tests/test_engine_tracing.py
@@ -174,22 +174,42 @@ def test_export_skips_when_there_is_nothing_to_send(monkeypatch):
     assert posts == [], "an empty collector must not hit the network"
 
 
-def test_agentor_native_wires_a_tracer_when_configured(monkeypatch):
+def test_a_key_alone_does_not_enable_tracing(monkeypatch):
+    """Tracing is opt-in: having a Celesto key is not consent to send runs."""
     from agentor import config as config_module
 
-    monkeypatch.setattr(
-        config_module.celesto_config, "api_key", _Secret("cel_test"), raising=False
-    )
-    monkeypatch.setattr(
-        config_module.celesto_config, "disable_auto_tracing", False, raising=False
-    )
+    monkeypatch.setattr(config_module.celesto_config, "api_key", _Secret("cel_test"))
+
+    from agentor import Agentor
+
+    agent = Agentor(name="T", model=FakeModel(text("x")), api_key="test")
+    assert agent._loop.tracer is None
+
+
+def test_enable_tracing_wires_a_tracer(monkeypatch):
+    from agentor import config as config_module
+
+    monkeypatch.setattr(config_module.celesto_config, "api_key", _Secret("cel_test"))
 
     from agentor import Agentor
 
     agent = Agentor(
-        name="T", model=FakeModel(text("x")), engine="native", api_key="test"
+        name="T", model=FakeModel(text("x")), api_key="test", enable_tracing=True
     )
     assert isinstance(agent._loop.tracer, CelestoTracer)
+
+
+def test_enable_tracing_without_a_key_raises(monkeypatch):
+    from agentor import config as config_module
+
+    monkeypatch.setattr(config_module.celesto_config, "api_key", None)
+
+    from agentor import Agentor
+
+    with pytest.raises(ValueError, match="API key is required"):
+        Agentor(
+            name="T", model=FakeModel(text("x")), api_key="test", enable_tracing=True
+        )
 
 
 class _Secret:

--- a/tests/test_tracing_control.py
+++ b/tests/test_tracing_control.py
@@ -139,7 +139,7 @@ async def test_agentor_stream_chat_can_opt_out():
 
 
 def test_tracing_true_builds_a_tracer_from_the_api_key(monkeypatch):
-    """Opting a single run in should work even when auto-tracing is off."""
+    """Opting one run in should work without tracing the whole agent."""
     from agentor import config as config_module
     from agentor.engine.tracing import CelestoTracer
 
@@ -148,10 +148,9 @@ def test_tracing_true_builds_a_tracer_from_the_api_key(monkeypatch):
             return "cel_test"
 
     monkeypatch.setattr(config_module.celesto_config, "api_key", _Secret())
-    monkeypatch.setattr(config_module.celesto_config, "disable_auto_tracing", True)
 
     agent = native(FakeModel(text("hi")))
-    assert agent._loop.tracer is None, "auto-tracing is off"
+    assert agent._loop.tracer is None, "tracing is opt-in"
 
     agent._resolve_tracing(True)
     assert isinstance(agent._loop.tracer, CelestoTracer)
@@ -161,7 +160,6 @@ def test_tracing_true_without_any_key_explains_itself(monkeypatch):
     from agentor import config as config_module
 
     monkeypatch.setattr(config_module.celesto_config, "api_key", None)
-    monkeypatch.setattr(config_module.celesto_config, "disable_auto_tracing", True)
 
     agent = native(FakeModel(text("hi")))
     with pytest.raises(ValueError, match="requires a Celesto API key"):

--- a/tests/test_tracing_control.py
+++ b/tests/test_tracing_control.py
@@ -138,8 +138,13 @@ async def test_agentor_stream_chat_can_opt_out():
     assert tracer.exported == []
 
 
-def test_tracing_true_builds_a_tracer_from_the_api_key(monkeypatch):
-    """Opting one run in should work without tracing the whole agent."""
+def test_tracing_true_builds_a_tracer_without_storing_it(monkeypatch):
+    """Opting one run in must not enrol every run after it.
+
+    Storing the on-demand tracer on the agent would mean a single
+    `tracing=True` call quietly turned tracing on for good - the exact leak
+    this API exists to prevent.
+    """
     from agentor import config as config_module
     from agentor.engine.tracing import CelestoTracer
 
@@ -152,8 +157,52 @@ def test_tracing_true_builds_a_tracer_from_the_api_key(monkeypatch):
     agent = native(FakeModel(text("hi")))
     assert agent._loop.tracer is None, "tracing is opt-in"
 
-    agent._resolve_tracing(True)
-    assert isinstance(agent._loop.tracer, CelestoTracer)
+    resolved = agent._resolve_tracing(True)
+    assert isinstance(resolved, CelestoTracer), "the run gets a tracer"
+    assert agent._loop.tracer is None, "but the agent does not keep it"
+
+
+def test_an_opted_in_run_does_not_trace_later_runs(monkeypatch):
+    """End-to-end version of the leak: run one traced, the next must not be."""
+    from agentor import config as config_module
+    from agentor.core import agent as agent_module
+
+    exported = []
+
+    class Cap:
+        def collector(self, workflow_name, **kwargs):
+            return TraceCollector(workflow_name, **kwargs)
+
+        def export(self, collector):
+            exported.append(1)
+
+    class _Secret:
+        def get_secret_value(self):
+            return "cel_test"
+
+    monkeypatch.setattr(config_module.celesto_config, "api_key", _Secret())
+    monkeypatch.setattr(agent_module, "setup_celesto_tracing", lambda **kwargs: Cap())
+
+    agent = native(FakeModel(text("1"), text("2"), text("3")))
+
+    agent.run("trace this one", tracing=True)
+    assert exported == [1]
+
+    agent.run("this one should not be traced")
+    agent.run("nor this one")
+    assert exported == [1], "a one-off opt-in leaked into later runs"
+
+
+@pytest.mark.asyncio
+async def test_a_tracer_object_can_be_passed_for_a_single_run():
+    tracer = RecordingTracer()
+    loop = AgentLoop(model=FakeModel(text("a"), text("b")))
+
+    await loop.arun("traced", tracing=tracer)
+    await loop.arun("not traced")
+
+    assert len(tracer.exported) == 1
+    assert loop.tracer is None, "a per-run tracer must not attach to the loop"
 
 
 def test_tracing_true_without_any_key_explains_itself(monkeypatch):

--- a/tests/test_tracing_control.py
+++ b/tests/test_tracing_control.py
@@ -1,0 +1,168 @@
+"""Per-run control over tracing.
+
+Tracing ships run contents - prompts, tool arguments, tool results - to a
+remote endpoint, so whether a given run is traced needs to be answerable per
+call, not only when the agent is built.
+"""
+
+import pytest
+
+from agentor.engine import AgentLoop
+from agentor.engine.tracing import TraceCollector
+from tests.test_engine import FakeModel, calls, text, weather
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.exported = []
+
+    def collector(self, workflow_name, **kwargs):
+        return TraceCollector(workflow_name, **kwargs)
+
+    def export(self, collector):
+        self.exported.append(collector.items)
+
+
+# ------------------------------------------------------------ engine level
+
+
+@pytest.mark.asyncio
+async def test_tracing_defaults_to_the_configured_tracer():
+    tracer = RecordingTracer()
+    await AgentLoop(model=FakeModel(text("hi")), tracer=tracer).arun("go")
+    assert len(tracer.exported) == 1
+
+
+@pytest.mark.asyncio
+async def test_tracing_false_sends_nothing_for_that_run():
+    tracer = RecordingTracer()
+    loop = AgentLoop(model=FakeModel(text("a"), text("b")), tracer=tracer)
+
+    await loop.arun("traced")
+    await loop.arun("private", tracing=False)
+    await loop.arun("traced again")
+
+    assert len(tracer.exported) == 2, "the opted-out run must not be exported"
+
+
+@pytest.mark.asyncio
+async def test_tracing_false_does_not_disturb_the_run():
+    tracer = RecordingTracer()
+    result = await AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "X"}')), text("done")),
+        tools=[weather],
+        tracer=tracer,
+    ).arun("go", tracing=False)
+
+    assert result.final_output == "done"
+    assert [e.result for e in result.events if e.type == "tool_result"] == ["X: sunny"]
+    assert tracer.exported == []
+
+
+@pytest.mark.asyncio
+async def test_tracing_true_without_a_tracer_is_an_error_not_a_silent_noop():
+    loop = AgentLoop(model=FakeModel(text("hi")))
+    with pytest.raises(ValueError, match="no tracer is configured"):
+        await loop.arun("go", tracing=True)
+
+
+@pytest.mark.asyncio
+async def test_tracing_true_uses_the_configured_tracer():
+    tracer = RecordingTracer()
+    await AgentLoop(model=FakeModel(text("hi")), tracer=tracer).arun("go", tracing=True)
+    assert len(tracer.exported) == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_honours_the_flag():
+    tracer = RecordingTracer()
+    loop = AgentLoop(model=FakeModel(text("hi")), tracer=tracer)
+
+    async for _ in loop.astream("go", tracing=False):
+        pass
+
+    assert tracer.exported == []
+
+
+def test_sync_run_honours_the_flag():
+    tracer = RecordingTracer()
+    AgentLoop(model=FakeModel(text("hi")), tracer=tracer).run("go", tracing=False)
+    assert tracer.exported == []
+
+
+# ------------------------------------------------------------ Agentor level
+
+
+def native(model, **kwargs):
+    from agentor import Agentor
+
+    return Agentor(name="T", model=model, api_key="test", **kwargs)
+
+
+def test_agentor_run_can_opt_out():
+    tracer = RecordingTracer()
+    agent = native(FakeModel(text("hi")), tracer=tracer)
+
+    agent.run("private", tracing=False)
+    assert tracer.exported == []
+
+    agent.run("traced")
+    assert len(tracer.exported) == 1
+
+
+@pytest.mark.asyncio
+async def test_agentor_arun_can_opt_out():
+    tracer = RecordingTracer()
+    agent = native(FakeModel(text("hi")), tracer=tracer)
+
+    await agent.arun("private", tracing=False)
+    assert tracer.exported == []
+
+
+@pytest.mark.asyncio
+async def test_agentor_batch_opt_out_covers_every_prompt():
+    """A batch run fans out; the flag has to reach each one."""
+    tracer = RecordingTracer()
+    agent = native(FakeModel(*[text("x")] * 4), tracer=tracer)
+
+    await agent.arun(["a", "b", "c"], tracing=False)
+    assert tracer.exported == []
+
+
+@pytest.mark.asyncio
+async def test_agentor_stream_chat_can_opt_out():
+    tracer = RecordingTracer()
+    agent = native(FakeModel(text("hi")), tracer=tracer)
+
+    _ = [c async for c in agent.stream_chat("go", serialize=False, tracing=False)]
+    assert tracer.exported == []
+
+
+def test_tracing_true_builds_a_tracer_from_the_api_key(monkeypatch):
+    """Opting a single run in should work even when auto-tracing is off."""
+    from agentor import config as config_module
+    from agentor.engine.tracing import CelestoTracer
+
+    class _Secret:
+        def get_secret_value(self):
+            return "cel_test"
+
+    monkeypatch.setattr(config_module.celesto_config, "api_key", _Secret())
+    monkeypatch.setattr(config_module.celesto_config, "disable_auto_tracing", True)
+
+    agent = native(FakeModel(text("hi")))
+    assert agent._loop.tracer is None, "auto-tracing is off"
+
+    agent._resolve_tracing(True)
+    assert isinstance(agent._loop.tracer, CelestoTracer)
+
+
+def test_tracing_true_without_any_key_explains_itself(monkeypatch):
+    from agentor import config as config_module
+
+    monkeypatch.setattr(config_module.celesto_config, "api_key", None)
+    monkeypatch.setattr(config_module.celesto_config, "disable_auto_tracing", True)
+
+    agent = native(FakeModel(text("hi")))
+    with pytest.raises(ValueError, match="requires a Celesto API key"):
+        agent.run("go", tracing=True)


### PR DESCRIPTION
Two changes to the same story: tracing no longer turns itself on, and it can be decided per run.

## Before

Tracing enabled itself whenever `CELESTO_API_KEY` was set. Every control was **construction-time only** — `enable_tracing=`, `tracer=`, or `CELESTO_DISABLE_AUTO_TRACING`. So an agent was traced or not for its whole life, and merely holding a Celesto key opted you in.

That key is also what the Celesto SDK and the MCP hub authenticate with. Holding it was never consent to ship **prompts, tool arguments and tool results** to a remote endpoint.

## Now

**Opt in explicitly:**

```python
agent = Agentor(name="A", enable_tracing=True)   # needs CELESTO_API_KEY
agent = Agentor(name="A", tracer=my_tracer)      # or bring your own
```

**Or decide per run:**

```python
agent.run("public question")
agent.run("contains customer data", tracing=False)  # this run sends nothing
agent.run("debug this", tracing=True)               # trace just this one
```

`tracing=` is accepted by `run`, `arun`, `chat`, `stream_chat`, and the engine's `run`/`arun`/`astream`. `None` keeps the agent's configuration, `False` disables that run, `True` traces it even when the agent has tracing off.

Per-run is the right axis because whether a run should be traced is a property of **that input**, not of the agent — one agent routinely handles both a public question and one containing customer data.

## Removed

- `CELESTO_DISABLE_AUTO_TRACING`, along with the behaviour it existed to switch off. Anyone who had it set wanted no auto-tracing, which is now the default — their intent is preserved.
- The startup notice. There's nothing to announce when nothing happens implicitly.

## Breaking

**Agents traced purely because `CELESTO_API_KEY` was present will stop producing traces** until `enable_tracing=True` is passed.

This is deliberate and **silent**. A runtime nag would be noise for the many users who hold that key for the SDK rather than for observability — and the changelog is the right channel for an upgrade note, not stdout on every construction.

## Design note

`tracing=True` on an agent with no tracer builds one from `CELESTO_API_KEY` rather than erroring — someone asking to trace one run while the agent has tracing off is making a sensible request. It raises only when there's no key at all; silently doing nothing is the worst outcome for someone debugging.

## Verification

- `263 passed` (13 new), covering: a key alone does **not** enable tracing and prints nothing, `enable_tracing=True` does, missing key raises, setup failure leaves a usable agent, per-run opt-out across sync/async/streaming/batch fan-out, on-demand tracer construction
- Live: with a key set and no opt-in, `tracer is None`; with `enable_tracing=True`, a `CelestoTracer`. A traced run exported 5 spans; the next with `tracing=False` completed normally and exported nothing
- **Ruff fully clean** — down from 6 pre-existing errors
- README rewritten to lead with "off unless you ask for it" and to say plainly what a trace contains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tracing is now explicitly opt-in and configurable per run.
- Removes API-key-driven automatic tracing and its disable environment variable.
- Adds per-run tracing overrides across synchronous, asynchronous, streaming, batch, and engine APIs.
- Builds one-off tracers without retaining them on the agent or loop.
- Adds documentation and tests for opt-in, opt-out, setup failure, and tracer-isolation behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/core/agent.py | Makes native tracing opt-in and resolves per-run overrides without persisting on-demand tracers. |
| src/agentor/engine/loop.py | Selects and exports through a run-local tracer across synchronous, asynchronous, and streaming execution. |
| src/agentor/config.py | Removes the obsolete automatic-tracing disable configuration. |
| tests/test_tracing_control.py | Covers per-run tracing behavior, including isolation from subsequent default runs. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Agentor
    participant AgentLoop
    participant Tracer
    Caller->>Agentor: "run(input, tracing=override)"
    Agentor->>Agentor: resolve tracing override
    Agentor->>AgentLoop: "run(input, tracing=resolved)"
    AgentLoop->>AgentLoop: select tracer for this run
    opt tracer selected
        AgentLoop->>Tracer: create collector
        AgentLoop->>Tracer: export run trace
    end
    AgentLoop-->>Caller: run result
```

<sub>Reviews (3): Last reviewed commit: ["fix: a one-off tracing opt-in must not e..."](https://github.com/celestoai/agentor/commit/dddfaec26660f4ff8abf93f1875f15445f417112) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48348761)</sub>

<!-- /greptile_comment -->