### PR TITLE
fix(tests): config tests must not depend on the developer's env

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,13 +3,28 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from agentor.config import CelestoConfig, celesto_config
+
+# CelestoConfig reads the process environment, and importing agentor.tools
+# calls load_dotenv(), so a developer's own .env leaks into any test asserting
+# defaults. CI has no .env and passes either way, which is how that goes
+# unnoticed.
+_CONFIG_ENV = ("CELESTO_API_KEY", "CELESTO_BASE_URL")
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Remove Celesto settings from the environment for one test."""
+    for name in _CONFIG_ENV:
+        monkeypatch.delenv(name, raising=False)
 
 
 class TestCelestoConfig:
     """Test suite for CelestoConfig class."""
 
-    def test_default_values(self):
+    def test_default_values(self, clean_env):
         """Test CelestoConfig default values."""
         config = CelestoConfig()
 
@@ -52,10 +67,25 @@ class TestCelestoConfig:
             # But should be accessible via get_secret_value()
             assert config.api_key.get_secret_value() == "secret-key"
 
-    def test_global_config_instance(self):
-        """Test that celesto_config is a valid instance."""
+    def test_global_config_instance(self, clean_env):
+        """Test that celesto_config is a valid instance.
+
+        Its value is fixed at import time, so this checks the type and the
+        shape rather than a base_url that a developer may legitimately have
+        pointed elsewhere.
+        """
         assert isinstance(celesto_config, CelestoConfig)
-        assert celesto_config.base_url == "https://api.celesto.ai/v1"
+        assert isinstance(celesto_config.base_url, str)
+        assert celesto_config.base_url.startswith("http")
+
+    def test_defaults_are_not_affected_by_a_developer_env(self, monkeypatch):
+        """The default test must not depend on who is running it."""
+        monkeypatch.setenv("CELESTO_API_KEY", "someone-local-key")
+        assert CelestoConfig().api_key is not None
+
+        for name in _CONFIG_ENV:
+            monkeypatch.delenv(name, raising=False)
+        assert CelestoConfig().api_key is None
 
 
 class TestCelestoConfigFieldAliases:


### PR DESCRIPTION
Found while verifying the tracing work on prod: adding a real `CELESTO_API_KEY` to `.env` turned the suite red on `main`.

## The failure

```
def test_default_values(self):
    config = CelestoConfig()
>   assert config.api_key is None
E   AssertionError: assert SecretStr('**********') is None
```

`CelestoConfig` reads the process environment, and importing `agentor.tools` calls `load_dotenv()`. So a developer's own `.env` leaks into a test named *"default values"*.

## Why it hid

- **CI has no `.env`**, so it passed there — and would have kept passing while being red for every contributor holding a Celesto key.
- **It only failed in the full suite.** Running `test_config.py` alone never imports the module that calls `load_dotenv()`, so it passed in isolation. That combination makes it look like flakiness rather than a real defect.

## Fix

- Tests asserting defaults clear `CELESTO_API_KEY` / `CELESTO_BASE_URL` first.
- `test_global_config_instance` asserted a specific `base_url`, which a developer may legitimately have pointed at staging. It now checks type and shape.
- Added `test_defaults_are_not_affected_by_a_developer_env`, which sets a key, asserts it's picked up, clears it, and asserts the default returns — so the isolation itself is pinned and can't regress quietly.

## Verification

- `266 passed` **with** a real key in `.env` (previously 1 failed)
- `9 passed` in `test_config.py` with the env cleared, i.e. the CI case
- Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes configuration tests independent of developer environment variables.
- Adds a fixture that removes Celesto configuration variables before default-value assertions.
- Retains exact default-value coverage using a freshly constructed configuration.
- Adjusts the import-time global singleton test to allow intentional environment overrides.
- Adds coverage showing that clearing a temporary API key restores the default behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed tests correctly isolating process-environment configuration.

Exact defaults remain tested on a clean, freshly constructed configuration, while the import-time singleton check appropriately permits intentional environment overrides.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/test_config.py | The new environment-isolation fixture prevents local `.env` values from contaminating default configuration tests while preserving exact default coverage. |

<sub>Reviews (1): Last reviewed commit: ["fix(tests): config tests must not depend..."](https://github.com/celestoai/agentor/commit/cc63aaf2df2f15cc3ae93728fb018e8992d67854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48355822)</sub>

<!-- /greptile_comment -->