### PR TITLE
fix: expose max_tool_failures and trace grouping, fix resumed usage

### DIFF
--- a/src/agentor/core/agent.py
+++ b/src/agentor/core/agent.py
@@ -126,9 +126,12 @@ class Agentor:
         skills: Optional[List[str]] = None,
         enable_tracing: bool = False,
         max_turns: int = 20,
+        max_tool_failures: int = 2,
         store: Any = None,
         base_url: Optional[str] = None,
         tracer: Any = None,
+        trace_group_id: Optional[str] = None,
+        trace_metadata: Optional[Dict[str, Any]] = None,
         engine: Optional[Literal["native"]] = None,
     ):
         if engine not in (None, "native"):
@@ -149,11 +152,14 @@ class Agentor:
             api_key=api_key,
             model_settings=model_settings,
             max_turns=max_turns,
+            max_tool_failures=max_tool_failures,
             enable_tracing=enable_tracing,
             store=store,
             output_type=output_type,
             base_url=base_url,
             tracer=tracer,
+            trace_group_id=trace_group_id,
+            trace_metadata=trace_metadata,
         )
 
     def _init_native(
@@ -165,11 +171,14 @@ class Agentor:
         api_key: Optional[str],
         model_settings: Optional[ModelSettings],
         max_turns: int,
+        max_tool_failures: int,
         enable_tracing: bool,
         store: Any = None,
         output_type: Any = None,
         base_url: Optional[str] = None,
         tracer: Any = None,
+        trace_group_id: Optional[str] = None,
+        trace_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Set up the native engine (see agentor.engine)."""
 
@@ -201,9 +210,12 @@ class Agentor:
             tools=self._tools,
             context=CelestoConfig(),
             max_turns=max_turns,
+            max_tool_failures=max_tool_failures,
             api_key=api_key,
             base_url=base_url,
             tracer=tracer,
+            trace_group_id=trace_group_id,
+            trace_metadata=trace_metadata,
             store=store,
             mcp_servers=mcp_servers,
             output_type=output_type,

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -101,6 +101,8 @@ class AgentLoop:
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         tracer: Any = None,
+        trace_group_id: Optional[str] = None,
+        trace_metadata: Optional[Dict[str, Any]] = None,
         store: Any = None,
         mcp_servers: Optional[List[Any]] = None,
         output_type: Any = None,
@@ -112,6 +114,8 @@ class AgentLoop:
         self.max_turns = max_turns
         self.max_tool_failures = max_tool_failures
         self.tracer = tracer
+        self.trace_group_id = trace_group_id
+        self.trace_metadata = trace_metadata
         self.store = store
         self.mcp_servers = list(mcp_servers or [])
         self.output_type = output_type
@@ -325,7 +329,15 @@ class AgentLoop:
         trace from being exported; `arun` always drains it.
         """
         tracer = self._tracer_for_run(tracing)
-        collector = tracer.collector(self.name) if tracer else None
+        collector = (
+            tracer.collector(
+                self.name,
+                group_id=self.trace_group_id,
+                metadata=self.trace_metadata,
+            )
+            if tracer
+            else None
+        )
         run_started = time.time()
 
         async def record(event: Event) -> None:
@@ -627,6 +639,10 @@ class AgentLoop:
         result = await self.arun(messages, run_id=run_id)
         # the caller cares about the whole run, not just this continuation
         result.events = events + result.events
+        # ...including what it cost. The continuation's run_end only counts its
+        # own generations, so billing a resumed run from it hides everything
+        # spent before the interruption.
+        result.usage = total_usage(result.events)
         return result
 
     def resume(self, run_id: str) -> RunResult:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,13 +3,28 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from agentor.config import CelestoConfig, celesto_config
+
+# CelestoConfig reads the process environment, and importing agentor.tools
+# calls load_dotenv(), so a developer's own .env leaks into any test asserting
+# defaults. CI has no .env and passes either way, which is how that goes
+# unnoticed.
+_CONFIG_ENV = ("CELESTO_API_KEY", "CELESTO_BASE_URL")
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Remove Celesto settings from the environment for one test."""
+    for name in _CONFIG_ENV:
+        monkeypatch.delenv(name, raising=False)
 
 
 class TestCelestoConfig:
     """Test suite for CelestoConfig class."""
 
-    def test_default_values(self):
+    def test_default_values(self, clean_env):
         """Test CelestoConfig default values."""
         config = CelestoConfig()
 
@@ -52,10 +67,25 @@ class TestCelestoConfig:
             # But should be accessible via get_secret_value()
             assert config.api_key.get_secret_value() == "secret-key"
 
-    def test_global_config_instance(self):
-        """Test that celesto_config is a valid instance."""
+    def test_global_config_instance(self, clean_env):
+        """Test that celesto_config is a valid instance.
+
+        Its value is fixed at import time, so this checks the type and the
+        shape rather than a base_url that a developer may legitimately have
+        pointed elsewhere.
+        """
         assert isinstance(celesto_config, CelestoConfig)
-        assert celesto_config.base_url == "https://api.celesto.ai/v1"
+        assert isinstance(celesto_config.base_url, str)
+        assert celesto_config.base_url.startswith("http")
+
+    def test_defaults_are_not_affected_by_a_developer_env(self, monkeypatch):
+        """The default test must not depend on who is running it."""
+        monkeypatch.setenv("CELESTO_API_KEY", "someone-local-key")
+        assert CelestoConfig().api_key is not None
+
+        for name in _CONFIG_ENV:
+            monkeypatch.delenv(name, raising=False)
+        assert CelestoConfig().api_key is None
 
 
 class TestCelestoConfigFieldAliases:

--- a/tests/test_docs_audit_fixes.py
+++ b/tests/test_docs_audit_fixes.py
@@ -1,0 +1,174 @@
+"""Regression tests for gaps found while writing the v0.1.0 documentation.
+
+Each was a capability the engine had but no caller could reach, or a number
+the API reported wrongly - the kind of thing that surfaces when someone tries
+to write an accurate example rather than read the code.
+"""
+
+import pytest
+
+from agentor import Agentor
+from agentor.engine import AgentLoop
+from agentor.engine.store import MemoryStore, total_usage
+from agentor.engine.tracing import TraceCollector
+from tests.test_engine import FakeModel, calls, text, weather
+
+
+class CapturingTracer:
+    def __init__(self):
+        self.collector_kwargs = None
+        self.exported = []
+
+    def collector(self, workflow_name, **kwargs):
+        self.collector_kwargs = kwargs
+        return TraceCollector(workflow_name, **kwargs)
+
+    def export(self, collector):
+        self.exported.append(collector.items)
+
+
+# ------------------------------------------------ max_tool_failures
+
+
+def test_max_tool_failures_is_reachable_from_agentor():
+    """The loop had the budget; Agentor never forwarded it."""
+    agent = Agentor(name="T", model="gpt-4o-mini", api_key="test", max_tool_failures=5)
+    assert agent._loop.max_tool_failures == 5
+
+
+def test_max_tool_failures_defaults_to_two():
+    agent = Agentor(name="T", model="gpt-4o-mini", api_key="test")
+    assert agent._loop.max_tool_failures == 2
+
+
+@pytest.mark.asyncio
+async def test_a_raised_budget_actually_allows_more_attempts():
+    executions = []
+
+    def flaky(x: str) -> str:
+        """Flaky.
+
+        Args:
+            x: anything.
+        """
+        executions.append(x)
+        raise RuntimeError("boom")
+
+    agent = Agentor(
+        name="T",
+        model=FakeModel(
+            calls(("flaky", '{"x": "1"}')),
+            calls(("flaky", '{"x": "2"}')),
+            calls(("flaky", '{"x": "3"}')),
+            text("giving up"),
+        ),
+        tools=[flaky],
+        api_key="test",
+        max_tool_failures=3,
+    )
+    await agent.arun("go")
+
+    assert executions == ["1", "2", "3"], "the configured budget was not applied"
+
+
+# ------------------------------------------------ trace grouping
+
+
+def test_trace_group_id_and_metadata_reach_the_collector():
+    """TraceCollector accepted them, but astream never passed them."""
+    tracer = CapturingTracer()
+    agent = Agentor(
+        name="T",
+        model=FakeModel(text("hi")),
+        api_key="test",
+        tracer=tracer,
+        trace_group_id="session-42",
+        trace_metadata={"env": "prod"},
+    )
+    agent.run("go")
+
+    assert tracer.collector_kwargs == {
+        "group_id": "session-42",
+        "metadata": {"env": "prod"},
+    }
+
+
+def test_trace_grouping_lands_on_the_exported_trace():
+    tracer = CapturingTracer()
+    AgentLoop(
+        model=FakeModel(text("hi")),
+        tracer=tracer,
+        trace_group_id="session-7",
+        trace_metadata={"tenant": "acme"},
+    ).run("go")
+
+    (items,) = tracer.exported
+    trace = items[0]
+    assert trace["object"] == "trace"
+    assert trace["group_id"] == "session-7"
+    assert trace["metadata"] == {"tenant": "acme"}
+
+
+def test_grouping_is_optional():
+    tracer = CapturingTracer()
+    AgentLoop(model=FakeModel(text("hi")), tracer=tracer).run("go")
+
+    (items,) = tracer.exported
+    assert items[0]["group_id"] is None
+
+
+# ------------------------------------------------ resumed usage
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_run_reports_what_the_whole_run_cost():
+    """The continuation's run_end counts only its own generations."""
+    store = MemoryStore()
+    first = await AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "X"}'))),
+        tools=[weather],
+        store=store,
+        max_turns=1,
+    ).arun("go")
+
+    resumed = await AgentLoop(
+        model=FakeModel(text("done")), tools=[weather], store=store
+    ).aresume(first.run_id)
+
+    logged = total_usage(store.load(first.run_id))
+    assert resumed.usage.total_tokens == logged.total_tokens
+    assert resumed.usage.total_tokens > first.usage.total_tokens, (
+        "a resumed run that costs more than the first attempt must say so"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resuming_a_finished_run_reports_its_full_cost():
+    store = MemoryStore()
+    first = await AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "X"}')), text("done")),
+        tools=[weather],
+        store=store,
+    ).arun("go")
+
+    resumed = await AgentLoop(model=FakeModel(), store=store).aresume(first.run_id)
+    assert resumed.usage.total_tokens == first.usage.total_tokens
+
+
+def test_sync_resume_reports_total_usage():
+    store = MemoryStore()
+    loop = AgentLoop(
+        model=FakeModel(calls(("weather", '{"city": "X"}'))),
+        tools=[weather],
+        store=store,
+        max_turns=1,
+    )
+    first = loop.run("go")
+
+    resumed = AgentLoop(
+        model=FakeModel(text("done")), tools=[weather], store=store
+    ).resume(first.run_id)
+
+    assert (
+        resumed.usage.total_tokens == total_usage(store.load(first.run_id)).total_tokens
+    )


### PR DESCRIPTION
Three gaps surfaced by the documentation pass — each a capability the engine **had** but no caller could reach, or a number the API reported **wrongly**.

Worth noting how they were found: by trying to write an accurate example, not by reading the code. Four codex reviews and 275 tests missed all three, because every one of them is invisible unless you attempt to *use* the feature from outside.

**Stacked on #149** — without it the suite is red for anyone with a Celesto key.

## 1. `max_tool_failures` was unreachable

`AgentLoop` takes it. `Agentor` never forwarded it:

```python
Agentor(name="A", max_tool_failures=3)
# TypeError: __init__() got an unexpected keyword argument 'max_tool_failures'
```

So the failure budget was permanently 2, and the docs had to describe it as fixed. Now forwarded, with a test that a raised budget genuinely allows more attempts.

## 2. Trace grouping was unreachable

`TraceCollector` accepts `group_id` and `metadata` — but `astream` called `collector(self.name)` with no arguments, so **both were silently dropped**. Per-session trace grouping, which the old docs promised, was impossible.

```python
agent = Agentor(name="A", trace_group_id="session-42", trace_metadata={"env": "prod"})
```

Now carried onto the exported trace, verified end-to-end.

## 3. A resumed run under-reported its cost

```
interrupted run:      3 tokens
resumed result.usage: 3 tokens   ← wrong
total in the log:     6 tokens
```

`aresume()` returned the continuation's `run_end` usage, which counts only its own generations. **Everything spent before the interruption was invisible** — bad for anyone costing a job, and worse the more times a run is resumed.

## Verification

- 9 new tests, and I confirmed **6 of them fail against the unfixed code** before trusting them — the other 3 assert defaults that were already correct
- `275 passed`, ruff clean

## Credit

Found by the agent writing the v0.1.0 docs. It also flagged that `stream_chat()` streams *steps*, not tokens — `event.chunk` is always `None`, so every `if event.chunk:` example in the old docs was dead code. That's documented rather than changed, since the step-level stream is what `serve()` and A2A consume; real token streaming is `AgentLoop.astream(..., stream_text=True)`. Worth deciding separately whether `stream_chat` should expose token deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes previously inaccessible engine configuration and corrects resumed-run usage accounting.
- Forwards max_tool_failures from Agentor into AgentLoop.
- Adds trace group and metadata configuration and passes it to trace collectors.
- Recomputes resumed-run usage across all generation events.
- Adds regression coverage and isolates configuration-default tests from developer environment variables.

<h3>Confidence Score: 3/5</h3>

The custom-tracer compatibility regression should be fixed before merging because traced runs can fail before model execution.

AgentLoop passes new keywords even when grouping is unused, while its tracer interface remains duck-typed and previously required only collector(workflow_name), so otherwise compatible external tracers can now raise TypeError.

**Files Needing Attention:** src/agentor/engine/loop.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/core/agent.py | Forwards the new tool-failure and trace-grouping options into the native engine. |
| src/agentor/engine/loop.py | Adds trace configuration and cumulative resumed usage, but the unconditional collector keywords break narrower existing custom tracers. |
| tests/test_config.py | Makes default-value tests less dependent on local Celesto environment variables. |
| tests/test_docs_audit_fixes.py | Covers the newly exposed options and resumed usage, but does not exercise backward compatibility with the former custom-tracer signature. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Agentor configuration] --> B[AgentLoop]
    B --> C[Tool failure budget]
    B --> D[Trace collector]
    E[Stored pre-interruption events] --> F[aresume]
    F --> G[Continuation events]
    E --> H[total_usage]
    G --> H
    H --> I[Resumed RunResult]
```

<sub>Reviews (1): Last reviewed commit: ["fix: expose max\_tool\_failures and trace ..."](https://github.com/celestoai/agentor/commit/d542f5f7f30be6af968770ff229a917e076e9821) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48358181)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for repeated tool failures, defaulting to two attempts.
  * Added optional trace grouping and metadata settings for improved run organization and context.

* **Bug Fixes**
  * Resumed runs now report total usage across the complete execution, including earlier events.
  * Configuration defaults are no longer affected by local environment variables.

* **Tests**
  * Added coverage for tool-failure limits, trace metadata, and usage reporting across synchronous and asynchronous runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->