### PR TITLE
release: 0.1.0a2

### DIFF
--- a/src/agentor/__init__.py
+++ b/src/agentor/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"
 
 __all__ = [
     "Agentor",


### PR DESCRIPTION
Version bump only — everything in it is already merged and green on `main`.

## Why now

`v0.1.0a1` was tagged **before** the tracing work landed. So the alpha currently on PyPI still **auto-enables tracing whenever `CELESTO_API_KEY` is set** — the exact behaviour that was then removed. Anyone running `pip install --pre agentor` today gets it, along with the one-off-opt-in leak Greptile caught.

That's the case for cutting a2 rather than waiting.

## What it carries

| PR | |
|---|---|
| [#148](https://github.com/CelestoAI/agentor/pull/148) | **Breaking:** tracing is opt-in; per-run `tracing=` control; fix for a one-off opt-in enrolling every later run |
| [#149](https://github.com/CelestoAI/agentor/pull/149) | Config tests no longer depend on the developer's environment |
| [#150](https://github.com/CelestoAI/agentor/pull/150) | `max_tool_failures` and trace grouping reachable; resumed runs report their full cost |

## Verification

- `275 passed`, ruff clean
- Builds as `agentor-0.1.0a2.tar.gz` / `.whl`
- Tracing verified against **production Celesto**: 3 opted-in runs produced exactly 3 traces readable back from `GET /v1/traces`; the 5 runs that didn't opt in left nothing

Changelog is drafted and ready for the release body.

## Note on tagging

`release.yml` fires on `v*.*.*`, and `v0.1.0a2` matches — tagging publishes to PyPI in the same action, no separate gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the package version from `0.1.0a1` to `0.1.0a2`; build metadata dynamically reads this value, so generated artifacts will carry the new version.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the version bump is consistent with the package’s dynamic build metadata and prerelease validation.

The build configuration reads its version directly from `src/agentor/__init__.py`, and the new alpha version remains compatible with the existing release workflow and version tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/__init__.py | Bumps `__version__` to `0.1.0a2`, consistently updating the package version used by the build system. |

<sub>Reviews (1): Last reviewed commit: ["release: 0.1.0a2"](https://github.com/celestoai/agentor/commit/6bf5463bb32fba58640ccff3052537db9f16f4cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48359645)</sub>

<!-- /greptile_comment -->