### PR TITLE
release: 0.1.0rc1

### DIFF
--- a/src/agentor/__init__.py
+++ b/src/agentor/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.1.0a2"
+__version__ = "0.1.0rc1"
 
 __all__ = [
     "Agentor",

--- a/tests/test_engine_review_fixes.py
+++ b/tests/test_engine_review_fixes.py
@@ -864,21 +864,27 @@ def test_agentor_accepts_an_explicit_tracer():
 
 
 def test_version_is_a_valid_prerelease():
-    """0.1.0 ships as an alpha on purpose.
+    """The 0.1.0 line ships as a prerelease on purpose.
 
-    pip excludes prereleases by default, which is exactly what is wanted here:
-    this release drops a dependency, removes DurableAgent and drops hosted
-    tools, so `pip install --upgrade agentor` should NOT sweep 0.0.x users into
-    it. They opt in with --pre or an explicit pin.
+    pip excludes prereleases by default, which is exactly what is wanted: this
+    release drops a dependency, removes DurableAgent and drops hosted tools, so
+    `pip install --upgrade agentor` must not sweep 0.0.x users into it. They
+    opt in with --pre or an explicit pin.
+
+    The phase may advance a -> b -> rc without touching this test; going stable
+    is a deliberate decision that should have to change it.
     """
     from packaging.version import Version
 
     import agentor
 
     version = Version(agentor.__version__)
-    assert version.is_prerelease, "0.1.0 is intended to ship as a prerelease"
+    assert version.is_prerelease, (
+        f"{agentor.__version__} is stable; upgrading 0.0.x users into a "
+        "breaking release should be an explicit choice"
+    )
     assert version.base_version == "0.1.0"
-    assert version.pre[0] == "a", f"expected an alpha, got {agentor.__version__}"
+    assert version.pre[0] in ("a", "b", "rc"), agentor.__version__
 
 
 def test_the_previous_mcp_import_still_works():


### PR DESCRIPTION
Promotes the alpha to a release candidate. **No code changes since `0.1.0a2`** — same build, relabelled.

## Why rc rather than stable

The quality bar is met: 275 tests across 9 OS/Python combinations, six review passes, and live verification against OpenAI, OpenRouter and production Celesto.

What isn't met yet is **exposure**. `0.1.0a2` has been public for about an hour, with no user having exercised it. The alpha existed to learn how durable runs behave under real load and on providers I couldn't test — and none of that has come back yet.

Going stable also flips a switch that's easy to underrate: `pip install --upgrade agentor` would start sweeping **every 0.0.x user** into a release that drops a dependency, removes `DurableAgent` and drops hosted tools. Today they have to opt in with `--pre`. An rc keeps that protection while signalling the code is done rather than experimental.

Worth weighing against that: the docs pass found three real bugs *today* that four codex reviews and 275 tests all missed — reachability gaps invisible until someone tries to *use* the API from outside. That's the class of thing real users find, and an rc is the cheapest way to let them.

## One test change

`test_version_is_a_valid_prerelease` asserted an alpha specifically. It now accepts `a`/`b`/`rc` but still **fails on a stable version** — so promoting to 0.1.0 has to be a deliberate act that changes a test, rather than a version-string edit that quietly changes what happens to every existing user.

## Verification

- `275 passed`, ruff clean
- Builds as `agentor-0.1.0rc1.tar.gz` / `.whl`
- `0.1.0a2` verified installed from PyPI: opt-in tracing confirmed, openai-agents absent

Changelog drafted, written for someone on 0.0.x — full migration table, known limitations, and what we'd most like tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to **0.1.0rc1**, marking the release candidate stage.

* **Tests**
  * Updated version validation checks to support alpha, beta, and release-candidate prerelease phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR promotes the package from `0.1.0a2` to `0.1.0rc1`.
- Updates the package’s single version source to the release-candidate identifier.
- Broadens the prerelease test to accept alpha, beta, and release-candidate phases while continuing to reject stable releases.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the package metadata and prerelease safeguard remaining consistent.

The build system derives distribution metadata from the updated runtime version constant, and the revised test still rejects stable or incorrectly based versions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/__init__.py | Updates the package version to `0.1.0rc1`; build metadata derives from this same source. |
| tests/test_engine_review_fixes.py | Preserves the prerelease and `0.1.0` base-version safeguards while allowing progression through standard prerelease phases. |

<sub>Reviews (1): Last reviewed commit: ["release: 0.1.0rc1"](https://github.com/celestoai/agentor/commit/2446ba9275063ea97f1e063f1a51148119faa3b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48398851)</sub>

<!-- /greptile_comment -->