### PR TITLE
fix: tool failure budget no longer breaks the message sequence (0.1.0rc2)

### DIFF
--- a/src/agentor/__init__.py
+++ b/src/agentor/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0rc2"
 
 __all__ = [
     "Agentor",

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -8,6 +8,7 @@ is emitted as an `Event`, and `arun`/`run` are projections of `astream`.
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import time
@@ -373,7 +374,7 @@ class AgentLoop:
         try:
             async with self._connected_mcp_tools() as tools:
                 async for event in self._astream(
-                    messages, stream_text, tools, max_turns
+                    messages, stream_text, tools, max_turns, run_started
                 ):
                     await record(event)
                     yield event
@@ -404,6 +405,7 @@ class AgentLoop:
         stream_text: bool = False,
         tools: Optional[Dict[str, Tool]] = None,
         max_turns: Optional[int] = None,
+        run_started: Optional[float] = None,
     ) -> AsyncIterator[Event]:
         tools = self.tools if tools is None else tools
         turn_budget = self.max_turns if max_turns is None else max_turns
@@ -412,13 +414,16 @@ class AgentLoop:
         total = Usage()
 
         model_name = getattr(self.model, "model", None)
-        run_started = time.time()
+        # taken from the caller so run_start and run_end bound the same instant
+        run_started = time.time() if run_started is None else run_started
 
         for turn in range(1, turn_budget + 1):
             schemas = self._schemas(tools, disabled)
             # snapshot before the call: `messages` is appended to below, and a
-            # trace needs the request as it was actually sent
-            request_messages = [dict(m) for m in messages]
+            # trace needs the request as it was actually sent. Deep, because a
+            # shallow copy shares the nested tool_calls list, so a later
+            # in-place edit would rewrite an already-emitted trace.
+            request_messages = copy.deepcopy(messages)
             call_started = time.time()
 
             if stream_text:
@@ -500,11 +505,10 @@ class AgentLoop:
                     }
                 )
 
-                if (
-                    event.error is None
-                    or event.name not in tools
-                    or event.name in disabled
-                ):
+                # An unknown name is counted too: a model that keeps inventing
+                # one otherwise burns every turn, which is the failure this
+                # budget exists to stop.
+                if event.error is None or event.name in disabled:
                     continue
 
                 failures[event.name] = failures.get(event.name, 0) + 1
@@ -518,17 +522,24 @@ class AgentLoop:
             # notice mid-loop splits the run of `tool` messages answering one
             # assistant turn, and providers reject that outright - so the budget
             # meant to keep a run alive was ending it instead.
-            for name in newly_disabled:
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            f"The tool '{name}' failed {failures[name]} times "
-                            "and is now unavailable. Answer without it, or "
-                            "explain what you cannot do."
-                        ),
-                    }
-                )
+            #
+            # Skipped on the last turn: no model call follows to read it, and no
+            # generation would snapshot it, so it would only sit in the log
+            # looking like context a resumed run had.
+            if turn < turn_budget:
+                for name in newly_disabled:
+                    count = failures[name]
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                f"The tool '{name}' failed {count} "
+                                f"time{'s' if count != 1 else ''} and is now "
+                                "unavailable. Answer without it, or explain "
+                                "what you cannot do."
+                            ),
+                        }
+                    )
 
         yield Event(
             type="run_end",

--- a/src/agentor/engine/loop.py
+++ b/src/agentor/engine/loop.py
@@ -488,6 +488,7 @@ class AgentLoop:
                 *(self._run_tool(call, tools, disabled) for call in response.tool_calls)
             )
 
+            newly_disabled: List[str] = []
             for event in results:
                 event.turn = turn
                 yield event
@@ -511,17 +512,23 @@ class AgentLoop:
                     # Retrying a tool that keeps failing just burns turns. Drop
                     # it and let the model finish with what is left.
                     disabled.add(event.name)
-                    messages.append(
-                        {
-                            "role": "user",
-                            "content": (
-                                f"The tool '{event.name}' failed "
-                                f"{failures[event.name]} times and is now "
-                                "unavailable. Answer without it, or explain "
-                                "what you cannot do."
-                            ),
-                        }
-                    )
+                    newly_disabled.append(event.name)
+
+            # Deferred until every tool result for this turn is in. Appending a
+            # notice mid-loop splits the run of `tool` messages answering one
+            # assistant turn, and providers reject that outright - so the budget
+            # meant to keep a run alive was ending it instead.
+            for name in newly_disabled:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            f"The tool '{name}' failed {failures[name]} times "
+                            "and is now unavailable. Answer without it, or "
+                            "explain what you cannot do."
+                        ),
+                    }
+                )
 
         yield Event(
             type="run_end",

--- a/tests/test_message_sequence.py
+++ b/tests/test_message_sequence.py
@@ -11,10 +11,18 @@ budget while siblings were still pending split the run of tool messages. The
 feature meant to keep a run alive was ending it.
 """
 
+from collections import Counter
+from typing import Any, Dict, List, Sequence, Tuple
+
 import pytest
 
 from agentor.engine import AgentLoop
 from tests.test_engine import FakeModel, calls, text
+
+#: one entry of the OpenAI-shaped message list handed to a provider
+Message = Dict[str, Any]
+#: (tool_name, json_arguments), as accepted by tests.test_engine.calls
+ToolSpec = Tuple[str, str]
 
 
 def broken(x: str) -> str:
@@ -35,25 +43,36 @@ def working(x: str) -> str:
     return "fine"
 
 
-def assert_well_formed(messages):
-    """Every assistant tool_calls turn is answered contiguously."""
+def assert_well_formed(messages: Sequence[Message]) -> None:
+    """Every assistant tool_calls turn is answered exactly once, contiguously.
+
+    Compares multisets rather than draining a pending set: a duplicate reply to
+    one id, or a reply to an id that was never requested, is as invalid as a
+    missing one, and `set.discard` accepts both silently.
+    """
     for index, message in enumerate(messages):
         if message.get("role") != "assistant" or not message.get("tool_calls"):
             continue
 
-        pending = {call["id"] for call in message["tool_calls"]}
+        expected: Counter = Counter(call["id"] for call in message["tool_calls"])
+        observed: Counter = Counter()
+
         cursor = index + 1
         while cursor < len(messages) and messages[cursor]["role"] == "tool":
-            pending.discard(messages[cursor]["tool_call_id"])
+            observed[messages[cursor]["tool_call_id"]] += 1
             cursor += 1
 
-        assert not pending, (
-            f"tool_call_ids {sorted(pending)} were not answered contiguously; "
+        assert observed == expected, (
+            f"tool replies did not match the calls: missing "
+            f"{sorted((expected - observed).elements())}, unexpected "
+            f"{sorted((observed - expected).elements())}; "
             f"sequence was {[m['role'] for m in messages]}"
         )
 
 
-async def sequence_sent_to_model(specs, budget, turns):
+async def sequence_sent_to_model(
+    specs: Sequence[ToolSpec], budget: int, turns: int
+) -> List[Message]:
     """Run the loop and return the message list from the final request."""
     model = FakeModel(*([calls(*specs)] * turns), text("done"))
     loop = AgentLoop(model=model, tools=[broken, working], max_tool_failures=budget)

--- a/tests/test_message_sequence.py
+++ b/tests/test_message_sequence.py
@@ -12,7 +12,7 @@ feature meant to keep a run alive was ending it.
 """
 
 from collections import Counter
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import pytest
 
@@ -71,11 +71,23 @@ def assert_well_formed(messages: Sequence[Message]) -> None:
 
 
 async def sequence_sent_to_model(
-    specs: Sequence[ToolSpec], budget: int, turns: int
+    specs: Sequence[ToolSpec],
+    budget: int,
+    turns: int,
+    tools: Optional[Sequence[Callable[..., str]]] = None,
 ) -> List[Message]:
-    """Run the loop and return the message list from the final request."""
+    """Run the loop and return the message list from the final request.
+
+    `tools` defaults to the two defined above; pass it when a spec names
+    something else, or the call silently becomes an unknown-tool call and
+    exercises a different path than the test intends.
+    """
     model = FakeModel(*([calls(*specs)] * turns), text("done"))
-    loop = AgentLoop(model=model, tools=[broken, working], max_tool_failures=budget)
+    loop = AgentLoop(
+        model=model,
+        tools=list(tools if tools is not None else (broken, working)),
+        max_tool_failures=budget,
+    )
     await loop.arun("go")
     return model.calls[-1]["messages"]
 
@@ -181,3 +193,20 @@ async def test_the_run_completes_rather_than_raising():
 
     assert result.status == "completed"
     assert result.final_output == "answered without the broken tool"
+
+
+@pytest.mark.asyncio
+async def test_a_hallucinated_tool_name_is_bounded_by_the_budget():
+    """An unknown name used to bypass the budget and burn every turn."""
+    model = FakeModel(*[calls(("ghost", "{}")) for _ in range(10)])
+    loop = AgentLoop(model=model, tools=[working], max_turns=10, max_tool_failures=2)
+    result = await loop.arun("go")
+
+    errors = [e.error for e in result.events if e.type == "tool_result"]
+    assert errors.count("unknown tool") == 2, (
+        f"the budget did not engage; errors were {errors}"
+    )
+    assert any(
+        m["role"] == "user" and "'ghost'" in m["content"]
+        for m in model.calls[-1]["messages"]
+    ), "the model was never told to stop calling it"

--- a/tests/test_message_sequence.py
+++ b/tests/test_message_sequence.py
@@ -1,0 +1,164 @@
+"""The message list handed to the provider must always be well-formed.
+
+An assistant turn carrying `tool_calls` has to be followed directly by one
+`tool` message per call. Anything inserted in between - however sensible its
+content - makes the request invalid, and providers reject it outright rather
+than degrading.
+
+Reported against 0.1.0a2: the tool failure budget appended its "tool is now
+unavailable" notice from inside the loop over results, so a tool exhausting its
+budget while siblings were still pending split the run of tool messages. The
+feature meant to keep a run alive was ending it.
+"""
+
+import pytest
+
+from agentor.engine import AgentLoop
+from tests.test_engine import FakeModel, calls, text
+
+
+def broken(x: str) -> str:
+    """Always fails.
+
+    Args:
+        x: anything.
+    """
+    raise RuntimeError("backend down")
+
+
+def working(x: str) -> str:
+    """Always works.
+
+    Args:
+        x: anything.
+    """
+    return "fine"
+
+
+def assert_well_formed(messages):
+    """Every assistant tool_calls turn is answered contiguously."""
+    for index, message in enumerate(messages):
+        if message.get("role") != "assistant" or not message.get("tool_calls"):
+            continue
+
+        pending = {call["id"] for call in message["tool_calls"]}
+        cursor = index + 1
+        while cursor < len(messages) and messages[cursor]["role"] == "tool":
+            pending.discard(messages[cursor]["tool_call_id"])
+            cursor += 1
+
+        assert not pending, (
+            f"tool_call_ids {sorted(pending)} were not answered contiguously; "
+            f"sequence was {[m['role'] for m in messages]}"
+        )
+
+
+async def sequence_sent_to_model(specs, budget, turns):
+    """Run the loop and return the message list from the final request."""
+    model = FakeModel(*([calls(*specs)] * turns), text("done"))
+    loop = AgentLoop(model=model, tools=[broken, working], max_tool_failures=budget)
+    await loop.arun("go")
+    return model.calls[-1]["messages"]
+
+
+@pytest.mark.asyncio
+async def test_failing_tool_first_of_two_parallel_calls():
+    messages = await sequence_sent_to_model(
+        [("broken", '{"x": "1"}'), ("working", '{"x": "2"}')], budget=1, turns=1
+    )
+    assert_well_formed(messages)
+
+
+@pytest.mark.asyncio
+async def test_failing_tool_last_of_two_parallel_calls():
+    messages = await sequence_sent_to_model(
+        [("working", '{"x": "1"}'), ("broken", '{"x": "2"}')], budget=1, turns=1
+    )
+    assert_well_formed(messages)
+
+
+@pytest.mark.asyncio
+async def test_budget_exhausted_in_the_middle_of_three_calls():
+    messages = await sequence_sent_to_model(
+        [
+            ("working", '{"x": "1"}'),
+            ("broken", '{"x": "2"}'),
+            ("working", '{"x": "3"}'),
+        ],
+        budget=1,
+        turns=1,
+    )
+    assert_well_formed(messages)
+
+
+@pytest.mark.asyncio
+async def test_flaky_tool_retried_beside_a_working_one_on_the_default_budget():
+    """The ordinary case, and the one that fired on the default budget."""
+    messages = await sequence_sent_to_model(
+        [("broken", '{"x": "1"}'), ("working", '{"x": "2"}')], budget=2, turns=2
+    )
+    assert_well_formed(messages)
+
+
+@pytest.mark.asyncio
+async def test_two_tools_exhaust_their_budgets_in_the_same_turn():
+    def alsobroken(x: str) -> str:
+        """Also fails.
+
+        Args:
+            x: anything.
+        """
+        raise RuntimeError("also down")
+
+    model = FakeModel(
+        calls(("broken", '{"x": "1"}'), ("alsobroken", '{"x": "2"}')),
+        text("done"),
+    )
+    loop = AgentLoop(model=model, tools=[broken, alsobroken], max_tool_failures=1)
+    await loop.arun("go")
+
+    messages = model.calls[-1]["messages"]
+    assert_well_formed(messages)
+    notices = [
+        m
+        for m in messages
+        if m["role"] == "user" and "is now unavailable" in m["content"]
+    ]
+    assert len(notices) == 2, "each disabled tool should be announced"
+
+
+@pytest.mark.asyncio
+async def test_the_notice_still_reaches_the_model():
+    """Deferring the notice must not drop it."""
+    messages = await sequence_sent_to_model(
+        [("broken", '{"x": "1"}'), ("working", '{"x": "2"}')], budget=1, turns=1
+    )
+    assert any(
+        m["role"] == "user" and "'broken' failed" in m["content"] for m in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_run_is_unaffected():
+    messages = await sequence_sent_to_model(
+        [("working", '{"x": "1"}'), ("working", '{"x": "2"}')], budget=2, turns=1
+    )
+    assert_well_formed(messages)
+    assert not [
+        m for m in messages if m["role"] == "user" and "unavailable" in m["content"]
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_run_completes_rather_than_raising():
+    """The point of the budget: a misbehaving tool must not end the run."""
+    model = FakeModel(
+        calls(("broken", '{"x": "1"}'), ("working", '{"x": "2"}')),
+        text("answered without the broken tool"),
+    )
+    result = await AgentLoop(
+        model=model, tools=[broken, working], max_tool_failures=1
+    ).arun("go")
+
+    assert result.status == "completed"
+    assert result.final_output == "answered without the broken tool"


### PR DESCRIPTION
Reported against `0.1.0a2`. The report was correct in every particular — I reproduced all four shapes before changing anything. **Also bumps to `0.1.0rc2`**, since rc1 is the current prerelease on PyPI and has this bug.

## The bug

The "tool is now unavailable" notice was appended **from inside the loop over tool results**. So when a tool exhausted its budget while sibling results were still pending, the notice landed *between* two `tool` messages — splitting the run answering one assistant turn. Providers reject that outright:

```
An assistant message with 'tool_calls' must be followed by tool messages
responding to each 'tool_call_id'.
```

The budget exists to keep a run alive when a tool misbehaves. It was ending it.

## Reproduced before fixing

| Scenario | budget | Sequence | Valid |
|---|---|---|---|
| Failing tool **first** of two parallel | 1 | `assistant(calls) → tool → user → tool` | **no** |
| Failing tool **last** of two parallel | 1 | `assistant(calls) → tool → tool → user` | yes |
| Three parallel, budget hit mid-turn | 1 | `assistant(calls) → tool → tool → user → tool` | **no** |
| Flaky retried beside a working tool | **2 (default)** | `assistant(calls) → tool → user → tool` | **no** |

The last row is on the **default** budget, so this wasn't an artifact of lowering it — and it's the ordinary case: a flaky tool called alongside a working one. The run survived only when the exhausting call happened to be the last result of its turn.

## Fix

Exactly as suggested: collect the disabled tools during the loop, append their notices once every tool result for that turn is in. The model sees the same text.

## What my own test missed

There *was* a test for this feature. It asserted the tool stopped executing after its budget — and never looked at the message list sent on the next turn. It verified the effect on execution while being blind to the request that produced, which is where the failure lived.

`tests/test_message_sequence.py` asserts the **invariant** instead of the reported cases: every assistant turn carrying `tool_calls` is answered contiguously. **Four of its eight cases fail against the old code**, including simultaneous exhaustion of two tools and the default-budget path. That shape check will catch the next thing that inserts a message in the wrong place.

## On the `replay_messages` note

Better than feared. The notice is **normally preserved** through replay — `generation` events snapshot the entire request and `replay_messages` restores from that snapshot. Verified.

It's lost only when the notice lands on the final turn with no generation after it. Even then resume re-applies the budget: verified as 2 retries, then a clean completion. Bounded and self-correcting, so no disabled-state persistence here. Happy to add it if resume should carry that context explicitly.

## Release

Version bumped in this PR rather than a follow-up, so the fix and the release carrying it are one reviewable unit.

- `283 passed`, ruff clean
- Builds as `agentor-0.1.0rc2.tar.gz` / `.whl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool-failure handling to keep provider message sequences well-formed during tool execution.
  - Deferred “tool failed and is now unavailable” notices until after all tool results for the current generation are processed.
  - Prevented run errors when tools exhaust their failure/ retry limits, while preserving correct behavior for successful and retryable tools.

- **Tests**
  - Added message-sequence validation for parallel tool failures, mid-turn budget exhaustion, multiple tools exhausting budgets together, flaky retries, and healthy runs completing successfully.  

- **Chores**
  - Bumped the package version to `0.1.0rc2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves valid provider message ordering when tool failure budgets are exhausted.
- Defers tool-unavailability notices until every tool result for the assistant turn has been appended.
- Bounds repeated calls to unknown tools using the same failure budget.
- Uses stable run timestamps and deep request snapshots for tracing.
- Adds regression coverage for parallel tool failures and bumps the package version to 0.1.0rc2.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentor/engine/loop.py | Defers failure notices until tool replies are complete, bounds unknown tools, and improves trace snapshot and timing consistency. |
| tests/test_message_sequence.py | Adds invariant-based regression tests covering parallel failures, simultaneous exhaustion, retries, unknown tools, and healthy execution. |
| src/agentor/__init__.py | Updates the authoritative package version to 0.1.0rc2. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant M as Model
    participant L as AgentLoop
    participant T as Tools
    M->>L: assistant(tool_calls)
    L->>T: execute calls concurrently
    T-->>L: tool results
    L->>L: append all tool messages contiguously
    L->>L: update failure budgets
    L->>L: append unavailable notices
    L->>M: next well-formed request
```

<sub>Reviews (2): Last reviewed commit: ["fix: apply code review findings on the f..."](https://github.com/celestoai/agentor/commit/7f03e4c6f9b9de87587373252e89c45c1ec1a75a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48449229)</sub>

<!-- /greptile_comment -->